### PR TITLE
Add general mechanism of attention for message going from source to target cells of different ranks

### DIFF
--- a/test/base/test_aggregation.py
+++ b/test/base/test_aggregation.py
@@ -11,12 +11,12 @@ class TestAggregation:
 
     def test_update(self):
         """Test the update of messages."""
-        n_skeleton_out = 4
+        n_target_cells = 4
         out_channels = 8
-        inputs = torch.randn(n_skeleton_out, out_channels)
+        inputs = torch.randn(n_target_cells, out_channels)
         merge_layer = Aggregation(update_func="sigmoid")
         updated = merge_layer.update(inputs)
-        assert updated.shape == (n_skeleton_out, out_channels)
+        assert updated.shape == (n_target_cells, out_channels)
 
     def test_forward(self):
         """Test the forward pass of the merge layer."""

--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -124,40 +124,6 @@ class TestMessagePassing:
         result = self.att_mp_xavier_uniform.attention(x_source, x_target)
         assert result.shape == (n_messages,)
 
-    # def test_sparsify_message(self):
-    #     """Test sparsify_message."""
-    #     x = torch.tensor(
-    #         [
-    #             [
-    #                 1,
-    #                 2,
-    #             ],
-    #             [3, 4],
-    #             [5, 6],
-    #         ]
-    #     )
-    #     neighborhood = torch.sparse_coo_tensor(
-    #         indices=torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
-    #         values=torch.tensor([1, 2, 3, 4, 5, 6]),
-    #         size=(3, 3),
-    #     )
-    #     n_messages = 6
-
-    #     self.mp.message = self.custom_message.__get__(self.mp)
-    #     _ = self.mp.propagate(x, neighborhood)
-    #     x_sparse = self.mp.sparsify_message(x)
-    #     expected = torch.tensor([[1, 2], [3, 4], [5, 6], [3, 4], [5, 6], [5, 6]])
-    #     assert expected.shape == (n_messages, 2)
-    #     assert torch.allclose(x_sparse, expected)
-
-    # def test_get_x_i(self):
-    #     """Test get_x_i."""
-    #     x = torch.Tensor([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
-    #     self.mp.target_index_i = torch.LongTensor([1, 2, 0])
-    #     result = self.mp.get_x_i(x)
-    #     expected = torch.Tensor([[4, 5, 6], [7, 8, 9], [1, 2, 3]])
-    #     assert torch.allclose(result, expected)
-
     def test_aggregate(self):
         """Test aggregate."""
         x_message = torch.tensor([[1, 2], [3, 4], [5, 6], [3, 4], [5, 6], [5, 6]])

--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -64,22 +64,6 @@ class TestMessagePassing:
         self.mp_with_att.reset_parameters(gain=gain)
         assert self.mp_with_att.att_weight.shape == (4,)
 
-    def test_propagate(self):
-        """Test propagate."""
-        # Test without attention
-        result = self.mp.propagate(self.x_source, self.neighborhood)
-        assert result.shape == (3, 2)
-
-        # Test with attention (source & target on the same cells)
-        result = self.mp_with_att.propagate(self.x_source, self.neighborhood)
-        assert result.shape == (3, 2)
-
-        # Test with attention (source & target on different cells)
-        result = self.mp_with_att.propagate(
-            self.x_source, self.neighborhood_r_to_s, self.x_target
-        )
-        assert result.shape == (2, 2)
-
     def test_attention(self):
         """Test attention."""
         # Test with source & target on the same cells

--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -6,18 +6,9 @@ from topomodelx.base.message_passing import MessagePassing
 from topomodelx.utils.scatter import scatter
 
 
-class AttentionMessagePassing(MessagePassing):
-    """Class to test message passing with attention between cells of same ranks."""
-
-    def __init__(self, in_channels=None, att=False, initialization="xavier_uniform"):
-        super().__init__(att=att, initialization=initialization)
-        self.in_channels = in_channels
-        if att:
-            self.att_weight = torch.nn.Parameter(
-                torch.Tensor(
-                    2 * in_channels,
-                )
-            )
+def custom_message(x_source, x_target=None):
+    """Make custom message function."""
+    return x_source
 
 
 class TestMessagePassing:
@@ -25,13 +16,21 @@ class TestMessagePassing:
 
     def setup_method(self):
         """Make message_passing object."""
+        self.x_source = torch.tensor([[1, 2], [3, 4], [5, 6]]).float()
+        self.x_target = torch.tensor([[1, 2], [3, 4]]).float()
+        self.neighborhood = torch.sparse_coo_tensor(
+            torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
+            torch.tensor([1, 2, 3, 4, 5, 6]),
+            size=(3, 3),
+        ).float()
+        self.neighborhood_r_to_s = torch.sparse_coo_tensor(
+            indices=torch.tensor([[0, 0, 0, 1, 1], [0, 1, 2, 1, 2]]),
+            values=torch.tensor([1, 2, 3, 4, 5]),
+            size=(2, 3),
+        )
+
         self.mp = MessagePassing()
-        self.att_mp_xavier_uniform = AttentionMessagePassing(
-            in_channels=2, att=True, initialization="xavier_uniform"
-        )
-        self.att_mp_xavier_normal = AttentionMessagePassing(
-            in_channels=2, att=True, initialization="xavier_normal"
-        )
+        self.mp.message = custom_message
 
     def test_reset_parameters(self):
         """Test the reset of the parameters."""
@@ -40,108 +39,107 @@ class TestMessagePassing:
             self.mp.initialization = "invalid"
             self.mp.reset_parameters(gain=gain)
 
-        # Test xavier_uniform initialization
+        # Test xavier_uniform
         self.mp.initialization = "xavier_uniform"
         self.mp.weight = torch.nn.Parameter(torch.Tensor(3, 3))
         self.mp.reset_parameters(gain=gain)
         assert self.mp.weight.shape == (3, 3)
 
-        # Test xavier_normal initialization
+        # Test xavier_normal
         self.mp.initialization = "xavier_normal"
         self.mp.weight = torch.nn.Parameter(torch.Tensor(3, 3))
         self.mp.reset_parameters(gain=gain)
         assert self.mp.weight.shape == (3, 3)
 
-    def custom_message(self, x_source, x_target=None):
-        """Make custom message function."""
-        return x_source
+        # Test with attention weights & xavier_uniform
+        self.mp.att = True
+        self.mp.att_weight = torch.nn.Parameter(
+            torch.Tensor(
+                2 * 2,
+            )
+        )
+        self.mp.initialization = "xavier_uniform"
+        self.mp.reset_parameters(gain=gain)
+        assert self.mp.att_weight.shape == (4,)
+
+        # Test with attention weights & xavier_normal
+        self.mp.att = True
+        self.mp.att_weight = torch.nn.Parameter(
+            torch.Tensor(
+                2 * 2,
+            )
+        )
+        self.mp.initialization = "xavier_normal"
+        self.mp.reset_parameters(gain=gain)
+        assert self.mp.att_weight.shape == (4,)
 
     def test_propagate(self):
         """Test propagate."""
-        x_source = torch.tensor([[1, 2], [3, 4], [5, 6]])
-        neighborhood = torch.sparse_coo_tensor(
-            torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
-            torch.tensor([1, 2, 3, 4, 5, 6]),
-            size=(3, 3),
-        )
-        self.mp.message = self.custom_message.__get__(self.mp)
-
-        result = self.mp.propagate(x_source=x_source, neighborhood=neighborhood)
+        # Test without attention
+        self.mp.att = False
+        result = self.mp.propagate(self.x_source, self.neighborhood)
         assert result.shape == (3, 2)
 
-    def test_propagate_with_attention(self):
-        """Test propagate with attention."""
-        x_source = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-        neighborhood = torch.sparse_coo_tensor(
-            torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
-            torch.tensor([1, 2, 3, 4, 5, 6]),
-            size=(3, 3),
+        # Test with attention (source & target on the same cells)
+        self.mp.att = True
+        self.mp.att_weight = torch.nn.Parameter(
+            torch.Tensor(
+                2 * 2,
+            )
         )
-        self.att_mp_xavier_uniform.message = self.custom_message.__get__(self.mp)
-        result = self.att_mp_xavier_uniform.propagate(x_source, neighborhood)
-        expected_shape = (3, 2)
-        assert result.shape == expected_shape
 
-        self.att_mp_xavier_normal.message = self.custom_message.__get__(self.mp)
-        result = self.att_mp_xavier_normal.propagate(x_source, neighborhood)
-        expected_shape = (3, 2)
-        assert result.shape == expected_shape
+        result = self.mp.propagate(self.x_source, self.neighborhood)
+        assert result.shape == (3, 2)
 
-    def test_attention_between_cells_of_same_rank(self):
-        """Test propagate with attention between cells of different ranks."""
-        x_source = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-        neighborhood = torch.sparse_coo_tensor(
-            indices=torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 0]]),
-            values=torch.tensor([1, 2, 3, 4, 5, 6]),
-            size=(3, 3),
+        # Test with attention (source & target on different cells)
+        self.mp.att = True
+        self.mp.att_weight = torch.nn.Parameter(
+            torch.Tensor(
+                2 * 2,
+            )
         )
-        n_messages = 6
+        result = self.mp.propagate(
+            self.x_source, self.neighborhood_r_to_s, self.x_target
+        )
+        assert result.shape == (2, 2)
 
-        neighborhood = neighborhood.coalesce()
-        target_index_i, source_index_j = neighborhood.indices()
-        self.att_mp_xavier_uniform.target_index_i = target_index_i
-        self.att_mp_xavier_uniform.source_index_j = source_index_j
+    def test_attention(self):
+        """Test attention."""
+        self.mp.att = True
+        self.mp.att_weight = torch.nn.Parameter(
+            torch.Tensor(
+                2 * 2,
+            )
+        )
 
-        result = self.att_mp_xavier_uniform.attention(x_source)
+        # Test with source & target on the same cells
+        neighborhood = self.neighborhood.coalesce()
+        self.mp.target_index_i, self.mp.source_index_j = neighborhood.indices()
+        n_messages = len(
+            self.mp.target_index_i,
+        )
+        result = self.mp.attention(self.x_source)
         assert result.shape == (n_messages,)
 
-    def test_attention_between_cells_of_different_ranks(self):
-        """Test propagate with attention between cells of different ranks."""
-        x_source = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-        x_target = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-        neighborhood = torch.sparse_coo_tensor(
-            indices=torch.tensor([[0, 0, 0, 1, 1], [0, 1, 2, 1, 2]]),
-            values=torch.tensor([1, 2, 3, 4, 5]),
-            size=(2, 3),
+        # Test with source & target on different cells
+        neighborhood_r_to_s = self.neighborhood_r_to_s.coalesce()
+        self.mp.target_index_i, self.mp.source_index_j = neighborhood_r_to_s.indices()
+        n_messages = len(
+            self.mp.target_index_i,
         )
-        n_messages = 5
-
-        neighborhood = neighborhood.coalesce()
-        target_index_i, source_index_j = neighborhood.indices()
-        self.att_mp_xavier_uniform.target_index_i = target_index_i
-        self.att_mp_xavier_uniform.source_index_j = source_index_j
-
-        result = self.att_mp_xavier_uniform.attention(x_source, x_target)
+        result = self.mp.attention(self.x_source, self.x_target)
         assert result.shape == (n_messages,)
 
     def test_aggregate(self):
         """Test aggregate."""
         x_message = torch.tensor([[1, 2], [3, 4], [5, 6], [3, 4], [5, 6], [5, 6]])
-        self.mp.target_index_i = torch.tensor([0, 0, 0, 1, 1, 2])
+        self.mp.target_index_i = torch.tensor([0, 0, 1, 1, 2, 2])
 
         result = self.mp.aggregate(x_message)
-        expected = torch.tensor([[9, 12], [8, 10], [5, 6]])
+        expected = torch.tensor([[4, 6], [8, 10], [10, 12]])
         assert torch.allclose(result, expected)
 
     def test_forward(self):
         """Test forward."""
-        x = torch.tensor([[1, 2], [3, 4], [5, 6]])
-        neighborhood = torch.sparse_coo_tensor(
-            torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
-            torch.tensor([1, 2, 3, 4, 5, 6]),
-            size=(3, 3),
-        )
-        self.mp.message = self.custom_message.__get__(self.mp)
-        result = self.mp.forward(x, neighborhood)
-        expected_shape = (3, 2)
-        assert result.shape == expected_shape
+        result = self.mp.forward(self.x_source, self.neighborhood)
+        assert result.shape == (3, 2)

--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -20,7 +20,7 @@ class AttentionSameRankMP(MessagePassing):
             )
 
 
-class AttentionDifferentRankMP(MessagePassing):
+class AttentionDifferentRanksMP(MessagePassing):
     """Custom class that inherits from MessagePassing to define attention."""
 
     def __init__(self, in_channels=None, att=False, initialization="xavier_uniform"):
@@ -44,11 +44,14 @@ class TestMessagePassing:
     def setup_method(self, method):
         """Make message_passing object."""
         self.mp = MessagePassing()
-        self.attention_mp_xavier_uniform = AttentionSameRankMP(
+        self.att_mp_xavier_uniform = AttentionSameRankMP(
             in_channels=2, att=True, initialization="xavier_uniform"
         )
-        self.attention_mp_xavier_normal = AttentionSameRankMP(
+        self.att_mp_xavier_normal = AttentionSameRankMP(
             in_channels=2, att=True, initialization="xavier_normal"
+        )
+        self.att_mp_different_ranks = AttentionDifferentRanksMP(
+            in_channels=2, att=True, initialization="xavier_uniform"
         )
 
     def test_reset_parameters(self):
@@ -95,15 +98,54 @@ class TestMessagePassing:
             torch.tensor([1, 2, 3, 4, 5, 6]),
             size=(3, 3),
         )
-        self.attention_mp_xavier_uniform.message = self.custom_message.__get__(self.mp)
-        result = self.attention_mp_xavier_uniform.propagate(x, neighborhood)
+        self.att_mp_xavier_uniform.message = self.custom_message.__get__(self.mp)
+        result = self.att_mp_xavier_uniform.propagate(x, neighborhood)
         expected_shape = (3, 2)
         assert result.shape == expected_shape
 
-        self.attention_mp_xavier_normal.message = self.custom_message.__get__(self.mp)
-        result = self.attention_mp_xavier_normal.propagate(x, neighborhood)
+        self.att_mp_xavier_normal.message = self.custom_message.__get__(self.mp)
+        result = self.att_mp_xavier_normal.propagate(x, neighborhood)
         expected_shape = (3, 2)
         assert result.shape == expected_shape
+
+    def test_attention_between_cells_of_same_rank(self):
+        """Test propagate with attention between cells of different ranks."""
+        x = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        neighborhood = torch.sparse_coo_tensor(
+            indices=torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 0]]),
+            values=torch.tensor([1, 2, 3, 4, 5, 6]),
+            size=(3, 3),
+        )
+        n_messages = 6
+
+        neighborhood = neighborhood.coalesce()
+        target_index_i, source_index_j = neighborhood.indices()
+        self.att_mp_xavier_uniform.target_index_i = target_index_i
+        self.att_mp_xavier_uniform.source_index_j = source_index_j
+
+        result = self.att_mp_xavier_uniform.attention_between_cells_of_same_rank(x)
+        assert result.shape == (n_messages,)
+
+    def test_attention_between_cells_of_different_ranks(self):
+        """Test propagate with attention between cells of different ranks."""
+        x_source = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        x_target = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        neighborhood = torch.sparse_coo_tensor(
+            indices=torch.tensor([[0, 0, 0, 1, 1], [0, 1, 2, 1, 2]]),
+            values=torch.tensor([1, 2, 3, 4, 5]),
+            size=(2, 3),
+        )
+        n_messages = 5
+
+        neighborhood = neighborhood.coalesce()
+        target_index_i, source_index_j = neighborhood.indices()
+        self.att_mp_different_ranks.target_index_i = target_index_i
+        self.att_mp_different_ranks.source_index_j = source_index_j
+
+        result = self.att_mp_different_ranks.attention_between_cells_of_different_ranks(
+            x_source, x_target
+        )
+        assert result.shape == (n_messages,)
 
     def test_sparsify_message(self):
         """Test sparsify_message."""
@@ -118,8 +160,8 @@ class TestMessagePassing:
             ]
         )
         neighborhood = torch.sparse_coo_tensor(
-            torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
-            torch.tensor([1, 2, 3, 4, 5, 6]),
+            indices=torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
+            values=torch.tensor([1, 2, 3, 4, 5, 6]),
             size=(3, 3),
         )
         n_messages = 6
@@ -128,7 +170,7 @@ class TestMessagePassing:
         _ = self.mp.propagate(x, neighborhood)
         x_sparse = self.mp.sparsify_message(x)
         expected = torch.tensor([[1, 2], [3, 4], [5, 6], [3, 4], [5, 6], [5, 6]])
-        assert expected.shape == n_messages, 2
+        assert expected.shape == (n_messages, 2)
         assert torch.allclose(x_sparse, expected)
 
     def test_get_x_i(self):

--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -6,8 +6,8 @@ from topomodelx.base.message_passing import MessagePassing
 from topomodelx.utils.scatter import scatter
 
 
-class AttentionSameRankMP(MessagePassing):
-    """Custom class that inherits from MessagePassing to define attention."""
+class AttentionMessagePassing(MessagePassing):
+    """Class to test message passing with attention between cells of same ranks."""
 
     def __init__(self, in_channels=None, att=False, initialization="xavier_uniform"):
         super().__init__(att=att, initialization=initialization)
@@ -18,40 +18,19 @@ class AttentionSameRankMP(MessagePassing):
                     2 * in_channels,
                 )
             )
-
-
-class AttentionDifferentRanksMP(MessagePassing):
-    """Custom class that inherits from MessagePassing to define attention."""
-
-    def __init__(self, in_channels=None, att=False, initialization="xavier_uniform"):
-        super().__init__(att=att, initialization=initialization)
-        self.in_channels = in_channels
-        if att:
-            self.att_weight = torch.nn.Parameter(
-                torch.Tensor(
-                    2 * in_channels,
-                )
-            )
-
-    def attention(self, x_r, x_s):
-        """Compute attention weights for messages between cells of different ranks."""
-        return self.attention_between_cells_of_different_ranks(x_r, x_s)
 
 
 class TestMessagePassing:
     """Test the MessagePassing class."""
 
-    def setup_method(self, method):
+    def setup_method(self):
         """Make message_passing object."""
         self.mp = MessagePassing()
-        self.att_mp_xavier_uniform = AttentionSameRankMP(
+        self.att_mp_xavier_uniform = AttentionMessagePassing(
             in_channels=2, att=True, initialization="xavier_uniform"
         )
-        self.att_mp_xavier_normal = AttentionSameRankMP(
+        self.att_mp_xavier_normal = AttentionMessagePassing(
             in_channels=2, att=True, initialization="xavier_normal"
-        )
-        self.att_mp_different_ranks = AttentionDifferentRanksMP(
-            in_channels=2, att=True, initialization="xavier_uniform"
         )
 
     def test_reset_parameters(self):
@@ -139,10 +118,10 @@ class TestMessagePassing:
 
         neighborhood = neighborhood.coalesce()
         target_index_i, source_index_j = neighborhood.indices()
-        self.att_mp_different_ranks.target_index_i = target_index_i
-        self.att_mp_different_ranks.source_index_j = source_index_j
+        self.att_mp_xavier_uniform.target_index_i = target_index_i
+        self.att_mp_xavier_uniform.source_index_j = source_index_j
 
-        result = self.att_mp_different_ranks.attention_between_cells_of_different_ranks(
+        result = self.att_mp_xavier_uniform.attention_between_cells_of_different_ranks(
             x_source, x_target
         )
         assert result.shape == (n_messages,)

--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -3,12 +3,6 @@ import pytest
 import torch
 
 from topomodelx.base.message_passing import MessagePassing
-from topomodelx.utils.scatter import scatter
-
-
-def custom_message(x_source, x_target=None):
-    """Make custom message function."""
-    return x_source
 
 
 class TestMessagePassing:
@@ -18,11 +12,13 @@ class TestMessagePassing:
         """Make message_passing object."""
         self.x_source = torch.tensor([[1, 2], [3, 4], [5, 6]]).float()
         self.x_target = torch.tensor([[1, 2], [3, 4]]).float()
+
         self.neighborhood = torch.sparse_coo_tensor(
-            torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
-            torch.tensor([1, 2, 3, 4, 5, 6]),
+            indices=torch.tensor([[0, 0, 0, 1, 1, 2], [0, 1, 2, 1, 2, 2]]),
+            values=torch.tensor([1, 2, 3, 4, 5, 6]),
             size=(3, 3),
         ).float()
+
         self.neighborhood_r_to_s = torch.sparse_coo_tensor(
             indices=torch.tensor([[0, 0, 0, 1, 1], [0, 1, 2, 1, 2]]),
             values=torch.tensor([1, 2, 3, 4, 5]),
@@ -30,7 +26,12 @@ class TestMessagePassing:
         )
 
         self.mp = MessagePassing()
-        self.mp.message = custom_message
+        self.mp_with_att = MessagePassing(att=True)
+        self.mp_with_att.att_weight = torch.nn.Parameter(
+            torch.Tensor(
+                2 * 2,
+            )
+        )
 
     def test_reset_parameters(self):
         """Test the reset of the parameters."""
@@ -52,94 +53,80 @@ class TestMessagePassing:
         assert self.mp.weight.shape == (3, 3)
 
         # Test with attention weights & xavier_uniform
-        self.mp.att = True
-        self.mp.att_weight = torch.nn.Parameter(
-            torch.Tensor(
-                2 * 2,
-            )
-        )
-        self.mp.initialization = "xavier_uniform"
-        self.mp.reset_parameters(gain=gain)
-        assert self.mp.att_weight.shape == (4,)
+        self.mp_with_att.initialization = "xavier_uniform"
+        self.mp_with_att.weight = torch.nn.Parameter(torch.Tensor(3, 3))
+        self.mp_with_att.reset_parameters(gain=gain)
+        assert self.mp_with_att.att_weight.shape == (4,)
 
         # Test with attention weights & xavier_normal
-        self.mp.att = True
-        self.mp.att_weight = torch.nn.Parameter(
-            torch.Tensor(
-                2 * 2,
-            )
-        )
-        self.mp.initialization = "xavier_normal"
-        self.mp.reset_parameters(gain=gain)
-        assert self.mp.att_weight.shape == (4,)
+        self.mp_with_att.initialization = "xavier_normal"
+        self.mp_with_att.weight = torch.nn.Parameter(torch.Tensor(3, 3))
+        self.mp_with_att.reset_parameters(gain=gain)
+        assert self.mp_with_att.att_weight.shape == (4,)
 
     def test_propagate(self):
         """Test propagate."""
         # Test without attention
-        self.mp.att = False
         result = self.mp.propagate(self.x_source, self.neighborhood)
         assert result.shape == (3, 2)
 
         # Test with attention (source & target on the same cells)
-        self.mp.att = True
-        self.mp.att_weight = torch.nn.Parameter(
-            torch.Tensor(
-                2 * 2,
-            )
-        )
-
-        result = self.mp.propagate(self.x_source, self.neighborhood)
+        result = self.mp_with_att.propagate(self.x_source, self.neighborhood)
         assert result.shape == (3, 2)
 
         # Test with attention (source & target on different cells)
-        self.mp.att = True
-        self.mp.att_weight = torch.nn.Parameter(
-            torch.Tensor(
-                2 * 2,
-            )
-        )
-        result = self.mp.propagate(
+        result = self.mp_with_att.propagate(
             self.x_source, self.neighborhood_r_to_s, self.x_target
         )
         assert result.shape == (2, 2)
 
     def test_attention(self):
         """Test attention."""
-        self.mp.att = True
-        self.mp.att_weight = torch.nn.Parameter(
-            torch.Tensor(
-                2 * 2,
-            )
-        )
-
         # Test with source & target on the same cells
         neighborhood = self.neighborhood.coalesce()
-        self.mp.target_index_i, self.mp.source_index_j = neighborhood.indices()
+        (
+            self.mp_with_att.target_index_i,
+            self.mp_with_att.source_index_j,
+        ) = neighborhood.indices()
         n_messages = len(
-            self.mp.target_index_i,
+            self.mp_with_att.target_index_i,
         )
-        result = self.mp.attention(self.x_source)
+        result = self.mp_with_att.attention(self.x_source)
         assert result.shape == (n_messages,)
 
         # Test with source & target on different cells
         neighborhood_r_to_s = self.neighborhood_r_to_s.coalesce()
-        self.mp.target_index_i, self.mp.source_index_j = neighborhood_r_to_s.indices()
+        (
+            self.mp_with_att.target_index_i,
+            self.mp_with_att.source_index_j,
+        ) = neighborhood_r_to_s.indices()
         n_messages = len(
-            self.mp.target_index_i,
+            self.mp_with_att.target_index_i,
         )
-        result = self.mp.attention(self.x_source, self.x_target)
+        result = self.mp_with_att.attention(self.x_source, self.x_target)
         assert result.shape == (n_messages,)
 
     def test_aggregate(self):
         """Test aggregate."""
         x_message = torch.tensor([[1, 2], [3, 4], [5, 6], [3, 4], [5, 6], [5, 6]])
-        self.mp.target_index_i = torch.tensor([0, 0, 1, 1, 2, 2])
+        self.mp_with_att.target_index_i = torch.tensor([0, 0, 1, 1, 2, 2])
 
-        result = self.mp.aggregate(x_message)
+        result = self.mp_with_att.aggregate(x_message)
         expected = torch.tensor([[4, 6], [8, 10], [10, 12]])
         assert torch.allclose(result, expected)
 
     def test_forward(self):
         """Test forward."""
+        # Test without attention
         result = self.mp.forward(self.x_source, self.neighborhood)
         assert result.shape == (3, 2)
+
+        # Test with attention (source & target on the same cells)
+        result = self.mp_with_att.forward(self.x_source, self.neighborhood)
+        assert result.shape == (3, 2)
+
+        # Test with attention (source & target on different cells)
+        result = self.mp_with_att.forward(
+            self.x_source, self.neighborhood_r_to_s, self.x_target
+        )
+        assert result.shape == (2, 2)

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -37,6 +37,8 @@ class MessagePassing(torch.nn.Module):
         self.aggr_func = aggr_func
         self.att = att
         self.initialization = initialization
+        assert initialization in ["xavier_uniform", "xavier_normal"]
+        assert aggr_func in ["sum", "mean", "add"]
 
     def reset_parameters(self, gain=1.414):
         r"""Reset learnable parameters.
@@ -62,7 +64,8 @@ class MessagePassing(torch.nn.Module):
                 torch.nn.init.xavier_normal_(self.att_weight.view(-1, 1), gain=gain)
         else:
             raise RuntimeError(
-                f" weight initializer " f"'{self.initialization}' is not supported"
+                "Initialization method not recognized. "
+                "Should be either xavier_uniform or xavier_normal."
             )
 
     def message(self, x_source, x_target=None):
@@ -176,10 +179,6 @@ class MessagePassing(torch.nn.Module):
             Output features on target cells.
             Assumes that all target cells have the same rank s.
         """
-        assert isinstance(x_source, torch.Tensor)
-        assert isinstance(neighborhood, torch.Tensor)
-        assert neighborhood.ndim == 2
-
         neighborhood = neighborhood.coalesce()
         self.target_index_i, self.source_index_j = neighborhood.indices()
         neighborhood_values = neighborhood.values()

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -195,9 +195,7 @@ class MessagePassing(torch.nn.Module):
         if self.att:
             if neighborhood.shape[0] != neighborhood.shape[1]:
                 raise RuntimeError(
-                    "Attention mechanism is only implemented for messages passing "
-                    "between cells of same rank, i.e. for neighborhood matrices "
-                    "that are square."
+                    "Use attention mechanism between cells of different ranks."
                 )
             attention_values = self.attention(x)
 

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -67,7 +67,7 @@ class MessagePassing(torch.nn.Module):
                 f" weight initializer " f"'{self.initialization}' is not supported"
             )
 
-    def attention_between_cells_of_different_ranks(self, x_r, x_s):
+    def attention_between_cells_of_different_ranks(self, x_source, x_target):
         """Compute attention weights for messages between cells of different ranks.
 
         Notes
@@ -83,10 +83,10 @@ class MessagePassing(torch.nn.Module):
 
         Parameters
         ----------
-        x_r : torch.tensor, shape=[n_source_cells, in_channels]
+        x_source : torch.tensor, shape=[n_source_cells, in_channels]
             Input features on source cells.
             Assumes that all source cells have the same rank r.
-        x_s : torch.tensor, shape=[n_target_cells, in_channels]
+        x_target : torch.tensor, shape=[n_target_cells, in_channels]
             Input features on target cells.
             Assumes that all target cells have the same rank s.
 
@@ -96,7 +96,7 @@ class MessagePassing(torch.nn.Module):
             Attention weights.
         """
         x_per_source_target_pair = torch.cat(
-            [x_r[self.source_index_j], x_s[self.target_index_i]], dim=1
+            [x_source[self.source_index_j], x_target[self.target_index_i]], dim=1
         )
         return torch.nn.functional.elu(
             torch.matmul(x_per_source_target_pair, self.att_weight)

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -67,73 +67,6 @@ class MessagePassing(torch.nn.Module):
                 f" weight initializer " f"'{self.initialization}' is not supported"
             )
 
-    # def attention_between_cells_of_different_ranks(self, x_source, x_target):
-    #     """Compute attention weights for messages between cells of different ranks.
-
-    #     Notes
-    #     -----
-    #     The attention weights are given in the order of the (source, target) pairs
-    #     that correspond to non-zero coefficients in the neighborhood matrix.
-
-    #     For this reason, the attention weights are computed only after
-    #     self.target_index_i and self.source_index_j.
-
-    #     This mechanism works for neighborhood that between cells of same ranks.
-    #     In that case, we note that the neighborhood matrix is square.
-
-    #     Parameters
-    #     ----------
-    #     x_source : torch.tensor, shape=[n_source_cells, in_channels]
-    #         Input features on source cells.
-    #         Assumes that all source cells have the same rank r.
-    #     x_target : torch.tensor, shape=[n_target_cells, in_channels]
-    #         Input features on target cells.
-    #         Assumes that all target cells have the same rank s.
-
-    #     Returns
-    #     -------
-    #     _ : torch.tensor, shape = [n_messages, 1]
-    #         Attention weights.
-    #     """
-
-    # def attention_between_cells_of_same_rank(self, x):
-    #     """Compute attention weights for messages between cells of same rank.
-
-    #     This provides a default attention method to the layer.
-
-    #     Alternatively, users can choose to inherit from this class and overwrite
-    #     this method to provide their own attention mechanism.
-
-    #     Notes
-    #     -----
-    #     The attention weights are given in the order of the (source, target) pairs
-    #     that correspond to non-zero coefficients in the neighborhood matrix.
-
-    #     For this reason, the attention weights are computed only after
-    #     self.target_index_i and self.source_index_j.
-
-    #     This mechanism works for neighborhood that between cells of same ranks.
-    #     In that case, we note that the neighborhood matrix is square.
-
-    #     Parameters
-    #     ----------
-    #     x : torch.tensor, shape=[n_source_cells, in_channels]
-    #         Input features on source cells.
-    #         Assumes that all source cells have the same rank r.
-
-    #     Returns
-    #     -------
-    #     _ : torch.tensor
-    #         shape = [n_messages, 1]
-    #         Attention weights: one scalar per message between a source and a target cell.
-    #     """
-    #     x_per_source_target_pair = torch.cat(
-    #         [x[self.source_index_j], x[self.target_index_i]], dim=1
-    #     )
-    #     return torch.nn.functional.elu(
-    #         torch.matmul(x_per_source_target_pair, self.att_weight)
-    #     )
-
     def attention(self, x_source, x_target=None):
         """Compute attention weights for messages between cells of same rank.
 
@@ -207,10 +140,6 @@ class MessagePassing(torch.nn.Module):
             Assumes that all target cells have the same rank s.
         """
         aggr = scatter(self.aggr_func)
-        print("hello")
-        print(x_message.shape)
-        print(x_message)
-        print(self.target_index_i)
         out = aggr(x_message, self.target_index_i, 0)
         return out
 

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -9,14 +9,11 @@ class MessagePassing(torch.nn.Module):
     """MessagePassing.
 
     This class abstractly defines the mechanisms of message passing.
-
-    Notes
-    -----
     This class is not meant to be instantiated directly.
     Instead, it is meant to be inherited by other classes that will
     effectively define the message passing mechanism.
 
-    For example, this class does not have trainable weights.
+    Note that this class does not have trainable weights.
     The classes that inherit from it will define these weights.
 
     Parameters
@@ -126,7 +123,7 @@ class MessagePassing(torch.nn.Module):
         _ : Tensor, shape=[..., n_source_cells, channels]
             Weighted features on source cells of rank r.
         """
-        pass
+        return x_source
 
     def aggregate(self, x_message):
         """Aggregate values in input tensor.


### PR DESCRIPTION
This PR writes a general attention function that works for both:
- messages send from source cells to themselves, i.e. within the same skeleton of a given rank r.
- messages send from source cells to target cells that have different ranks, i.e. are from different skeletons.

In the process, this PR:
- refactorizes the MessagePassing class,
- cleans some unit-tests, to make them more "unit".