### PR TITLE
Add typing annotations throughout the project

### DIFF
--- a/topomodelx/base/aggregation.py
+++ b/topomodelx/base/aggregation.py
@@ -1,4 +1,5 @@
 """Aggregation module."""
+from typing import Literal
 
 import torch
 
@@ -17,9 +18,9 @@ class Aggregation(torch.nn.Module):
 
     def __init__(
         self,
-        aggr_func="sum",
-        update_func="sigmoid",
-    ):
+        aggr_func: Literal["mean", "sum"] = "sum",
+        update_func: Literal["relu", "sigmoid", "tanh"] | None = "sigmoid",
+    ) -> None:
         super().__init__()
         self.aggr_func = aggr_func
         self.update_func = update_func

--- a/topomodelx/base/conv.py
+++ b/topomodelx/base/conv.py
@@ -18,13 +18,12 @@ class Conv(MessagePassing):
         Dimension of input features.
     out_channels : int
         Dimension of output features.
-    aggr_norm : bool
+    aggr_norm : bool, default=False
         Whether to normalize the aggregated message by the neighborhood size.
-    update_func : string
+    update_func : string, optional
         Update method to apply to message.
-    att : bool
+    att : bool, default=False
         Whether to use attention.
-        Optional, default: False.
     initialization : string
         Initialization method.
     with_linear_transform: bool
@@ -36,12 +35,12 @@ class Conv(MessagePassing):
         self,
         in_channels,
         out_channels,
-        aggr_norm=False,
+        aggr_norm: bool = False,
         update_func=None,
-        att=False,
-        initialization="xavier_uniform",
-        with_linear_transform=True,
-    ):
+        att: bool = False,
+        initialization: str = "xavier_uniform",
+        with_linear_transform: bool = True,
+    ) -> None:
         super().__init__(
             att=att,
             initialization=initialization,

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -25,7 +25,7 @@ class MessagePassing(torch.nn.Module):
     ----------
     aggr_func : string
         Aggregation function to use.
-    att : bool
+    att : bool, default=False
         Whether to use attention.
     initialization : string
         Initialization method for the weights of the layer.
@@ -43,10 +43,10 @@ class MessagePassing(torch.nn.Module):
 
     def __init__(
         self,
-        aggr_func="sum",
-        att=False,
-        initialization="xavier_uniform",
-    ):
+        aggr_func: str = "sum",
+        att: bool = False,
+        initialization: str = "xavier_uniform",
+    ) -> None:
         super().__init__()
         self.aggr_func = aggr_func
         self.att = att
@@ -54,7 +54,7 @@ class MessagePassing(torch.nn.Module):
         assert initialization in ["xavier_uniform", "xavier_normal"]
         assert aggr_func in ["sum", "mean", "add"]
 
-    def reset_parameters(self, gain=1.414):
+    def reset_parameters(self, gain: float = 1.414):
         r"""Reset learnable parameters.
 
         Notes

--- a/topomodelx/nn/cell/can_layer.py
+++ b/topomodelx/nn/cell/can_layer.py
@@ -13,7 +13,7 @@ from topomodelx.base.message_passing import MessagePassing
 from topomodelx.utils.scatter import scatter_add, scatter_sum
 
 
-def softmax(src, index, num_cells):
+def softmax(src, index, num_cells: int):
     r"""Compute the softmax of the attention coefficients.
 
     Notes
@@ -111,7 +111,7 @@ class LiftLayer(MessagePassing):
         heads: int,
         signal_lift_activation: Callable,
         signal_lift_dropout: float,
-    ):
+    ) -> None:
         super(LiftLayer, self).__init__()
 
         self.in_channels_0 = in_channels_0
@@ -119,7 +119,7 @@ class LiftLayer(MessagePassing):
         self.signal_lift_activation = signal_lift_activation
         self.signal_lift_dropout = signal_lift_dropout
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reinitialize learnable parameters using Xavier uniform initialization."""
         gain = nn.init.calculate_gain("relu")
         nn.init.xavier_uniform_(self.att.data, gain=gain)
@@ -196,9 +196,7 @@ class MultiHeadLiftLayer(nn.Module):
         signal_lift_activation: Callable = torch.relu,
         signal_lift_dropout: float = 0.0,
         signal_lift_readout: str = "cat",
-        *args,
-        **kwargs,
-    ):
+    ) -> None:
         super(MultiHeadLiftLayer, self).__init__()
 
         assert heads > 0, ValueError("Number of heads must be > 0")
@@ -222,7 +220,7 @@ class MultiHeadLiftLayer(nn.Module):
         )
         self.reset_parameters()
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reinitialize learnable parameters using Xavier uniform initialization."""
         self.lifts.reset_parameters()
 
@@ -305,7 +303,7 @@ class PoolLayer(MessagePassing):
         in_channels_0: int,
         signal_pool_activation: Callable,
         readout: bool = True,
-    ):
+    ) -> None:
         super(PoolLayer, self).__init__()
 
         self.k_pool = k_pool
@@ -318,7 +316,7 @@ class PoolLayer(MessagePassing):
         # Initialize the attention parameter using Xavier initialization
         self.reset_parameters()
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reinitialize learnable parameters using Xavier uniform initialization."""
         gain = init.calculate_gain("relu")
         init.xavier_uniform_(self.att_pool.data, gain=gain)
@@ -427,7 +425,7 @@ class MultiHeadCellAttention(MessagePassing):
         add_self_loops: bool = False,
         aggr_func: str = "sum",
         initialization: str = "xavier_uniform",
-    ):
+    ) -> None:
         super().__init__(
             att=True,
             initialization=initialization,
@@ -448,7 +446,7 @@ class MultiHeadCellAttention(MessagePassing):
 
         self.reset_parameters()
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset the layer parameters."""
         torch.nn.init.xavier_uniform_(self.att_weight_src)
         torch.nn.init.xavier_uniform_(self.att_weight_dst)
@@ -621,7 +619,7 @@ class MultiHeadCellAttention_v2(MessagePassing):
         aggr_func: str = "sum",
         initialization: str = "xavier_uniform",
         share_weights: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             att=True,
             initialization=initialization,
@@ -652,7 +650,7 @@ class MultiHeadCellAttention_v2(MessagePassing):
 
         self.reset_parameters()
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset the layer parameters."""
         torch.nn.init.xavier_uniform_(self.att_weight)
         self.lin_src.reset_parameters()
@@ -831,12 +829,12 @@ class CANLayer(torch.nn.Module):
         skip_connection: bool = True,
         att_activation: torch.nn.Module = torch.nn.LeakyReLU(),
         add_self_loops: bool = False,
-        aggr_func="sum",
+        aggr_func: str = "sum",
         update_func: str = "relu",
         version: str = "v1",
         share_weights: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__()
 
         assert in_channels > 0, ValueError("Number of input channels must be > 0")
@@ -908,7 +906,7 @@ class CANLayer(torch.nn.Module):
 
         self.reset_parameters()
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset the parameters of the layer."""
         self.lower_att.reset_parameters()
         self.upper_att.reset_parameters()

--- a/topomodelx/nn/cell/can_layer_bis.py
+++ b/topomodelx/nn/cell/can_layer_bis.py
@@ -63,11 +63,11 @@ class CANLayer(torch.nn.Module):
     def __init__(
         self,
         channels,
-        activation="sigmoid",
-        att=True,
-        eps=1e-5,
-        initialization="xavier_uniform",
-    ):
+        activation: str = "sigmoid",
+        att: bool = True,
+        eps: float = 1e-5,
+        initialization: str = "xavier_uniform",
+    ) -> None:
         super().__init__()
         # Do I need upper and lower convolution layers? Since I think they will have different parameters
         self.conv_down = Conv(
@@ -96,7 +96,7 @@ class CANLayer(torch.nn.Module):
             self.att_weight = Parameter(torch.Tensor(channels, 1))
         self.reset_parameters()
 
-    def reset_parameters(self, gain=1.414):
+    def reset_parameters(self, gain: float = 1.414):
         """Reset learnable parameters.
 
         Parameters

--- a/topomodelx/nn/cell/ccxn_layer.py
+++ b/topomodelx/nn/cell/ccxn_layer.py
@@ -33,11 +33,13 @@ class CCXNLayer(torch.nn.Module):
         Dimension of input features on edges (1-cells).
     in_channels_2 : int
         Dimension of input features on faces (2-cells).
-    att : bool
+    att : bool, default=False
         Whether to use attention.
     """
 
-    def __init__(self, in_channels_0, in_channels_1, in_channels_2, att=False):
+    def __init__(
+        self, in_channels_0, in_channels_1, in_channels_2, att: bool = False
+    ) -> None:
         super().__init__()
         self.conv_0_to_0 = Conv(
             in_channels=in_channels_0, out_channels=in_channels_0, att=att

--- a/topomodelx/nn/cell/cwn_layer.py
+++ b/topomodelx/nn/cell/cwn_layer.py
@@ -41,31 +41,27 @@ class CWNLayer(nn.Module):
     out_channels : int
         Dimension of output features on r-cells.
 
-    conv_1_to_1 : torch.nn.Module
+    conv_1_to_1 : torch.nn.Module, optional
         A module that convolves the representations of upper-adjacent neighbors of r-cells
         and their corresponding co-boundary (r+1) cells.
-        Optional, default: None.
 
         If None is passed, a default implementation of this module is used
         (check the docstring of _CWNDefaultFirstConv for more detail).
 
-    conv_0_to_1 : torch.nn.Module
+    conv_0_to_1 : torch.nn.Module, optional
         A module that convolves the representations of (r-1)-cells on the boundary of r-cells.
-        Optional, default: None.
 
         If None is passed, a default implementation of this module is used
         (check the docstring of _CWNDefaultSecondConv for more detail).
 
-    aggregate_fn : torch.nn.Module
+    aggregate_fn : torch.nn.Module, optional
         A module that aggregates the representations of r-cells obtained by convolutional layers.
-        Optional, default: None.
 
         If None is passed, a default implementation of this module is used
         (check the docstring of _CWNDefaultAggregate for more detail).
 
-    update_fn : torch.nn.Module
+    update_fn : torch.nn.Module, optional
         A module that updates the aggregated representations of r-cells.
-        Optional, default: None.
 
         If None is passed, a default implementation of this module is used
         (check the docstring of _CWNDefaultUpdate for more detail).
@@ -81,7 +77,7 @@ class CWNLayer(nn.Module):
         conv_0_to_1=None,
         aggregate_fn=None,
         update_fn=None,
-    ):
+    ) -> None:
         super().__init__()
         self.conv_1_to_1 = (
             conv_1_to_1
@@ -208,7 +204,7 @@ class _CWNDefaultFirstConv(nn.Module):
     a protocol for the first convolutional step in CWN layer.
     """
 
-    def __init__(self, in_channels_1, in_channels_2, out_channels):
+    def __init__(self, in_channels_1, in_channels_2, out_channels) -> None:
         super().__init__()
         self.conv_1_to_1 = Conv(
             in_channels_1, out_channels, aggr_norm=False, update_func=None
@@ -251,7 +247,7 @@ class _CWNDefaultSecondConv(nn.Module):
     a protocol for the second convolutional step in CWN layer.
     """
 
-    def __init__(self, in_channels_0, in_channels_1, out_channels):
+    def __init__(self, in_channels_0, in_channels_1, out_channels) -> None:
         super().__init__()
         self.conv_0_to_1 = Conv(
             in_channels_0, out_channels, aggr_norm=False, update_func=None
@@ -287,7 +283,7 @@ class _CWNDefaultAggregate(nn.Module):
     a protocol for the aggregation step in CWN layer.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, x, y):
@@ -311,7 +307,7 @@ class _CWNDefaultAggregate(nn.Module):
 class _CWNDefaultUpdate(nn.Module):
     r"""Default implementation of an update step in CWNLayer."""
 
-    def __init__(self, in_channels, out_channels):
+    def __init__(self, in_channels, out_channels) -> None:
         super().__init__()
         self.transform = nn.Linear(in_channels, out_channels)
 

--- a/topomodelx/nn/hypergraph/allset_layer.py
+++ b/topomodelx/nn/hypergraph/allset_layer.py
@@ -16,28 +16,28 @@ class AllSetLayer(nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    dropout : float, optional
-        Dropout probability. Default is 0.2.
-    mlp_num_layers : int, optional
-        Number of layers in the MLP. Default is 2.
+    dropout : float, default=0.2
+        Dropout probability.
+    mlp_num_layers : int, default=2
+        Number of layers in the MLP.
     mlp_activation : callable or None, optional
-        Activation function in the MLP. Default is None.
+        Activation function in the MLP.
     mlp_dropout : float, optional
-        Dropout probability in the MLP. Default is 0.0.
+        Dropout probability in the MLP.
     mlp_norm : str or None, optional
-        Type of layer normalization in the MLP. Default is None.
+        Type of layer normalization in the MLP.
     """
 
     def __init__(
         self,
         in_channels,
         hidden_channels,
-        dropout=0.2,
-        mlp_num_layers=2,
+        dropout: float = 0.2,
+        mlp_num_layers: int = 2,
         mlp_activation=nn.ReLU,
-        mlp_dropout=0.0,
+        mlp_dropout: float = 0.0,
         mlp_norm=None,
-    ):
+    ) -> None:
         super().__init__()
 
         if mlp_num_layers <= 0:
@@ -64,7 +64,7 @@ class AllSetLayer(nn.Module):
             mlp_norm=mlp_norm,
         )
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset learnable parameters."""
         self.vertex2edge.reset_parameters()
         self.edge2vertex.reset_parameters()
@@ -123,28 +123,28 @@ class AllSetBlock(nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    dropout : float, optional
-        Dropout probability. Default is 0.2.
-    mlp_num_layers : int, optional
-        Number of layers in the MLP. Default is 2.
+    dropout : float, default=0.2
+        Dropout probability.
+    mlp_num_layers : int, default=2
+        Number of layers in the MLP.
     mlp_activation : callable or None, optional
-        Activation function in the MLP. Default is None.
+        Activation function in the MLP.
     mlp_dropout : float, optional
-        Dropout probability in the MLP. Default is 0.0.
+        Dropout probability in the MLP.
     mlp_norm : callable or None, optional
-        Type of layer normalization in the MLP. Default is None.
+        Type of layer normalization in the MLP.
     """
 
     def __init__(
         self,
         in_channels,
         hidden_channels,
-        dropout,
-        mlp_num_layers=2,
+        dropout: float = 0.2,
+        mlp_num_layers: int = 2,
         mlp_activation=nn.ReLU,
-        mlp_dropout=0.0,
+        mlp_dropout: float = 0.0,
         mlp_norm=None,
-    ):
+    ) -> None:
         super(AllSetBlock, self).__init__()
 
         self.dropout = dropout
@@ -177,7 +177,7 @@ class AllSetBlock(nn.Module):
             att=False,
         )
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset learnable parameters."""
         self.encoder.reset_parameters()
         self.decoder.reset_parameters()
@@ -219,15 +219,15 @@ class MLP(nn.Sequential):
     hidden_channels : list of int
         List of dimensions of the hidden features.
     norm_layer : callable or None, optional
-        Type of layer normalization. Default is None.
+        Type of layer normalization.
     activation_layer : callable or None, optional
-        Type of activation function. Default is None.
-    dropout : float, optional
-        Dropout probability. Default is 0.0.
-    inplace : bool, optional
-        Whether to do the operation in-place. Default is False.
-    bias : bool, optional
-        Whether to add bias. Default is True.
+        Type of activation function.
+    dropout : float, default=0.0
+        Dropout probability.
+    inplace : bool, default=False
+        Whether to do the operation in-place.
+    bias : bool, default=False
+        Whether to add bias.
     """
 
     def __init__(
@@ -236,10 +236,10 @@ class MLP(nn.Sequential):
         hidden_channels,
         norm_layer=None,
         activation_layer=None,
-        dropout=0.0,
-        inplace=None,
-        bias=False,
-    ):
+        dropout: float = 0.0,
+        inplace: bool | None = None,
+        bias: bool = False,
+    ) -> None:
         params = {} if inplace is None else {"inplace": inplace}
         layers = []
         in_dim = in_channels

--- a/topomodelx/nn/hypergraph/allset_transformer_layer.py
+++ b/topomodelx/nn/hypergraph/allset_transformer_layer.py
@@ -22,34 +22,32 @@ class AllSetTransformerLayer(nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    out_channels : int
-        Dimension of the output features.
-    num_heads : int, optional
-        Number of attention heads. Default is 4.
+    heads : int, default=4
+        Number of attention heads.
     dropout : float, optional
-        Dropout probability. Default is 0.2.
-    mlp_num_layers : int, optional
-        Number of layers in the MLP. Default is 2.
+        Dropout probability.
+    mlp_num_layers : int, default=1
+        Number of layers in the MLP.
     mlp_activation : callable or None, optional
-        Activation function in the MLP. Default is None.
+        Activation function in the MLP.
     mlp_dropout : float, optional
-        Dropout probability in the MLP. Default is 0.0.
+        Dropout probability in the MLP.
     mlp_norm : str or None, optional
-        Type of layer normalization in the MLP. Default is None.
+        Type of layer normalization in the MLP.
     """
 
     def __init__(
         self,
         in_channels,
         hidden_channels,
-        heads=4,
-        number_queries=1,
-        dropout=0.0,
-        mlp_num_layers=1,
+        heads: int = 4,
+        number_queries: int = 1,
+        dropout: float = 0.0,
+        mlp_num_layers: int = 1,
         mlp_activation=nn.ReLU,
-        mlp_dropout=0.0,
+        mlp_dropout: float = 0.0,
         mlp_norm=None,
-    ):
+    ) -> None:
         super().__init__()
 
         if heads <= 0:
@@ -89,7 +87,7 @@ class AllSetTransformerLayer(nn.Module):
             mlp_norm=mlp_norm,
         )
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset parameters."""
         self.vertex2edge.reset_parameters()
         self.edge2vertex.reset_parameters()
@@ -149,35 +147,35 @@ class AllSetTransformerBlock(nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    heads : int, optional
-        Number of attention heads. Default is 4.
-    number_queries : int, optional
-        Number of queries. Default is 1.
+    heads : int, default=4
+        Number of attention heads.
+    number_queries : int, default=1
+        Number of queries.
     dropout : float, optional
-        Dropout probability. Default is 0.0.
-    mlp_num_layers : int, optional
-        Number of layers in the MLP. Default is 1.
+        Dropout probability.
+    mlp_num_layers : int, default=1
+        Number of layers in the MLP.
     mlp_activation : callable or None, optional
-        Activation function in the MLP. Default is None.
+        Activation function in the MLP.
     mlp_dropout : float, optional
-        Dropout probability in the MLP. Default is 0.0.
+        Dropout probability in the MLP.
     mlp_norm : str or None, optional
-        Type of layer normalization in the MLP. Default is None.
+        Type of layer normalization in the MLP.
     """
 
     def __init__(
         self,
         in_channels,
         hidden_channels,
-        heads=4,
-        number_queries=1,
-        dropout=0.0,
-        mlp_num_layers=1,
+        heads: int = 4,
+        number_queries: int = 1,
+        dropout: float = 0.0,
+        mlp_num_layers: int = 1,
         mlp_activation=None,
-        mlp_dropout=0.0,
+        mlp_dropout: float = 0.0,
         mlp_norm=None,
-        initialization="xavier_uniform",
-    ):
+        initialization: str = "xavier_uniform",
+    ) -> None:
         super().__init__()
 
         self.in_channels = in_channels
@@ -208,7 +206,7 @@ class AllSetTransformerBlock(nn.Module):
 
         self.reset_parameters()
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.multihead_att.reset_parameters()
         for layer in self.mlp.children():
@@ -267,28 +265,28 @@ class MultiHeadAttention(MessagePassing):
         Dimension of input features.
     hidden_channels : int
         Dimension of hidden features.
-    aggr_norm : bool, optional
-        Whether to normalize the aggregated message by the neighborhood size. Default is False.
+    aggr_norm : bool, default=False
+        Whether to normalize the aggregated message by the neighborhood size.
     update_func : str or None, optional
-        Update method to apply to message. Default is None.
-    heads : int, optional
-        Number of attention heads. Default is 4.
-    number_queries : int, optional
-        Number of queries. Default is 1.
-    initialization : str, optional
-        Initialization method. Default is "xavier_uniform".
+        Update method to apply to message.
+    heads : int, default=4
+        Number of attention heads.
+    number_queries : int, default=1
+        Number of queries.
+    initialization : str, default="xavier_uniform"
+        Initialization method.
     """
 
     def __init__(
         self,
         in_channels,
         hidden_channels,
-        aggr_norm=False,
+        aggr_norm: bool = False,
         update_func=None,
-        heads=4,
-        number_queries=1,
-        initialization="xavier_uniform",
-    ):
+        heads: int = 4,
+        number_queries: int = 1,
+        initialization: str = "xavier_uniform",
+    ) -> None:
         super().__init__(
             att=True,
             initialization=initialization,
@@ -313,7 +311,7 @@ class MultiHeadAttention(MessagePassing):
             torch.randn(self.heads, self.in_channels, self.hidden_channels)
         )
 
-    def reset_parameters(self, gain=1.414):
+    def reset_parameters(self, gain: float = 1.414):
         r"""Reset learnable parameters."""
         if self.initialization == "xavier_uniform":
             torch.nn.init.xavier_uniform_(self.K_weight, gain=gain)
@@ -409,15 +407,15 @@ class MLP(nn.Sequential):
     hidden_channels : list of int
         List of dimensions of the hidden features.
     norm_layer : callable or None, optional
-        Type of layer normalization. Default is None.
+        Type of layer normalization
     activation_layer : callable or None, optional
-        Type of activation function. Default is None.
+        Type of activation function.
     dropout : float, optional
-        Dropout probability. Default is 0.0.
-    inplace : bool, optional
-        Whether to do the operation in-place. Default is False.
-    bias : bool, optional
-        Whether to add bias. Default is True.
+        Dropout probability.
+    inplace : bool, default=False
+        Whether to do the operation in-place.
+    bias : bool, default=False
+        Whether to add bias.
     """
 
     def __init__(
@@ -426,10 +424,10 @@ class MLP(nn.Sequential):
         hidden_channels,
         norm_layer=None,
         activation_layer=torch.nn.ReLU,
-        dropout=0.0,
-        inplace=None,
-        bias=False,
-    ):
+        dropout: float = 0.0,
+        inplace: bool | None = None,
+        bias: bool = False,
+    ) -> None:
         params = {} if inplace is None else {"inplace": inplace}
         layers = []
         in_dim = in_channels

--- a/topomodelx/nn/hypergraph/dhgcn_layer.py
+++ b/topomodelx/nn/hypergraph/dhgcn_layer.py
@@ -25,10 +25,10 @@ class DHGCNLayer(torch.nn.Module):
         in_channels,
         intermediate_channels,
         out_channels,
-        k_neighbours=3,
-        k_centroids=4,
-        device="cpu",
-    ):
+        k_neighbours: int = 3,
+        k_centroids: int = 4,
+        device: str = "cpu",
+    ) -> None:
         super().__init__()
 
         self.in_channels = in_channels
@@ -49,7 +49,7 @@ class DHGCNLayer(torch.nn.Module):
         )
 
     @staticmethod
-    def kmeans_graph(x, k, flow="source_to_target"):
+    def kmeans_graph(x, k, flow: str = "source_to_target"):
         r"""K-means algorithm implementation.
 
         Parameters
@@ -206,7 +206,7 @@ class DHGCNLayer(torch.nn.Module):
         x_0_features = self.conv_dt_level0_1_to_0(x_1, incidence_1_dynamic_topology)
         return x_0_features
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.fc_layer.reset_parameters()
         self.conv_dt_level0_0_to_1.reset_parameters()

--- a/topomodelx/nn/hypergraph/hmpnn_layer.py
+++ b/topomodelx/nn/hypergraph/hmpnn_layer.py
@@ -8,7 +8,7 @@ from topomodelx.utils.scatter import scatter
 
 
 class _AdjacencyDropoutMixin:
-    def apply_dropout(self, neighborhood, dropout_rate):
+    def apply_dropout(self, neighborhood, dropout_rate: float):
         neighborhood = neighborhood.coalesce()
         return torch.sparse_coo_tensor(
             neighborhood.indices(),
@@ -20,7 +20,9 @@ class _AdjacencyDropoutMixin:
 
 
 class _NodeToHyperedgeMessenger(MessagePassing, _AdjacencyDropoutMixin):
-    def __init__(self, messaging_func, adjacency_dropout=0.7, aggr_func="sum"):
+    def __init__(
+        self, messaging_func, adjacency_dropout: float = 0.7, aggr_func: str = "sum"
+    ) -> None:
         super().__init__(aggr_func)
         self.messaging_func = messaging_func
         self.adjacency_dropout = adjacency_dropout
@@ -43,9 +45,9 @@ class _HyperedgeToNodeMessenger(MessagePassing, _AdjacencyDropoutMixin):
     def __init__(
         self,
         messaging_func,
-        adjacency_dropout=0.7,
-        aggr_func="sum",
-    ):
+        adjacency_dropout: float = 0.7,
+        aggr_func: str = "sum",
+    ) -> None:
         super().__init__(aggr_func)
         self.messaging_func = messaging_func
         self.adjacency_dropout = adjacency_dropout
@@ -129,11 +131,11 @@ class HMPNNLayer(nn.Module):
         in_features,
         node_to_hyperedge_messaging_func=None,
         hyperedge_to_node_messaging_func=None,
-        adjacency_dropout=0.7,
-        aggr_func="sum",
-        updating_dropout=0.5,
+        adjacency_dropout: float = 0.7,
+        aggr_func: str = "sum",
+        updating_dropout: float = 0.5,
         updating_func=None,
-    ):
+    ) -> None:
         super().__init__()
 
         if node_to_hyperedge_messaging_func is None:

--- a/topomodelx/nn/hypergraph/hnhn_layer.py
+++ b/topomodelx/nn/hypergraph/hnhn_layer.py
@@ -57,13 +57,13 @@ class HNHNLayer(torch.nn.Module):
         channels_node,
         channels_edge,
         incidence_1,
-        use_bias=True,
-        use_normalized_incidence=True,
-        alpha=-1.5,
-        beta=-0.5,
-        bias_gain=1.414,
-        bias_init="xavier_uniform",
-    ):
+        use_bias: bool = True,
+        use_normalized_incidence: bool = True,
+        alpha: float = -1.5,
+        beta: float = -0.5,
+        bias_gain: float = 1.414,
+        bias_init: str = "xavier_uniform",
+    ) -> None:
         super().__init__()
         self.use_bias = use_bias
         self.bias_init = bias_init
@@ -96,7 +96,7 @@ class HNHNLayer(torch.nn.Module):
             self.compute_normalization_matrices()
             self.normalize_incidence_matrices()
 
-    def compute_normalization_matrices(self):
+    def compute_normalization_matrices(self) -> None:
         """Compute the normalization matrices for the incidence matrices."""
         B1 = self.incidence_1.to_dense()
         edge_cardinality = (B1.sum(0)) ** self.alpha
@@ -123,7 +123,7 @@ class HNHNLayer(torch.nn.Module):
         self.D0_right_beta = torch.diag(node_cardinality)
         return
 
-    def normalize_incidence_matrices(self):
+    def normalize_incidence_matrices(self) -> None:
         """Normalize the incidence matrices."""
         self.incidence_1 = (
             self.D0_left_alpha_inverse
@@ -137,7 +137,7 @@ class HNHNLayer(torch.nn.Module):
         ).to_sparse()
         return
 
-    def init_biases(self):
+    def init_biases(self) -> None:
         """Initialize the bias."""
         for bias in [self.bias_0_to_1, self.bias_1_to_0]:
             if self.bias_init == "xavier_uniform":
@@ -145,7 +145,7 @@ class HNHNLayer(torch.nn.Module):
             elif self.bias_init == "xavier_normal":
                 torch.nn.init.xavier_normal_(bias, gain=self.bias_gain)
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset learnable parameters."""
         self.conv_1_to_0.reset_parameters()
         self.conv_0_to_1.reset_parameters()

--- a/topomodelx/nn/hypergraph/hnhn_layer_bis.py
+++ b/topomodelx/nn/hypergraph/hnhn_layer_bis.py
@@ -32,9 +32,9 @@ class HNHNLayer(torch.nn.Module):
         in_features,
         incidence_1,
         activation_func=F.relu,
-        normalization_param_alpha=0.0,
-        normalization_param_beta=0.0,
-    ):
+        normalization_param_alpha: float = 0.0,
+        normalization_param_beta: float = 0.0,
+    ) -> None:
         super().__init__()
 
         incidence_1 = incidence_1.to(torch.float)

--- a/topomodelx/nn/hypergraph/hypergat_layer.py
+++ b/topomodelx/nn/hypergraph/hypergat_layer.py
@@ -29,8 +29,8 @@ class HyperGATLayer(MessagePassing):
         self,
         in_channels,
         out_channels,
-        update_func="relu",
-        initialization="xavier_uniform",
+        update_func: str = "relu",
+        initialization: str = "xavier_uniform",
     ) -> None:
         super().__init__(initialization=initialization)
         self.in_channels = in_channels
@@ -48,7 +48,7 @@ class HyperGATLayer(MessagePassing):
         self.att_weight2 = torch.nn.Parameter(torch.zeros(size=(2 * out_channels, 1)))
         self.reset_parameters()
 
-    def reset_parameters(self, gain=1.414):
+    def reset_parameters(self, gain: float = 1.414):
         r"""Reset parameters."""
         if self.initialization == "xavier_uniform":
             torch.nn.init.xavier_uniform_(self.weight1, gain=gain)
@@ -67,7 +67,7 @@ class HyperGATLayer(MessagePassing):
                 "Should be either xavier_uniform or xavier_normal."
             )
 
-    def attention(self, x_source, x_target=None, mechanism="node-level"):
+    def attention(self, x_source, x_target=None, mechanism: str = "node-level"):
         r"""Compute attention weights for messages, as proposed in [DWLLL20].
 
         Parameters

--- a/topomodelx/nn/hypergraph/hypersage_layer.py
+++ b/topomodelx/nn/hypergraph/hypersage_layer.py
@@ -16,7 +16,7 @@ class GeneralizedMean(Aggregation):
         Power for the generalized mean. Default is 2.
     """
 
-    def __init__(self, power: int = 2, **kwargs):
+    def __init__(self, power: int = 2, **kwargs) -> None:
         super().__init__(aggr_func="generalized_mean", **kwargs)
         self.power = power
 

--- a/topomodelx/nn/hypergraph/template_layer.py
+++ b/topomodelx/nn/hypergraph/template_layer.py
@@ -24,7 +24,7 @@ class TemplateLayer(torch.nn.Module):
         in_channels,
         intermediate_channels,
         out_channels,
-    ):
+    ) -> None:
         super().__init__()
 
         self.conv_level1_1_to_0 = Conv(
@@ -40,7 +40,7 @@ class TemplateLayer(torch.nn.Module):
             update_func="sigmoid",
         )
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.conv_level1_1_to_0.reset_parameters()
         self.conv_level2_0_to_1.reset_parameters()

--- a/topomodelx/nn/hypergraph/unigcn_layer.py
+++ b/topomodelx/nn/hypergraph/unigcn_layer.py
@@ -29,7 +29,9 @@ class UniGCNLayer(torch.nn.Module):
         Whether to normalize the aggregated message by the neighborhood size.
     """
 
-    def __init__(self, in_channels, out_channels, aggr_norm=False, use_bn=False):
+    def __init__(
+        self, in_channels, out_channels, aggr_norm: bool = False, use_bn: bool = False
+    ) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -48,7 +50,7 @@ class UniGCNLayer(torch.nn.Module):
         )
         self.bn = nn.BatchNorm1d(in_channels) if use_bn else None
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.conv_level1_0_to_1.reset_parameters()
         self.conv_level2_1_to_0.reset_parameters()

--- a/topomodelx/nn/hypergraph/unigcnii_layer.py
+++ b/topomodelx/nn/hypergraph/unigcnii_layer.py
@@ -21,7 +21,7 @@ class UniGCNIILayer(torch.nn.Module):
         2021. https://arxiv.org/pdf/2105.00956.pdf
     """
 
-    def __init__(self, in_channels, alpha, beta):
+    def __init__(self, in_channels, alpha: float, beta: float) -> None:
         super().__init__()
 
         self.in_channels = in_channels
@@ -29,7 +29,7 @@ class UniGCNIILayer(torch.nn.Module):
         self.beta = beta
         self.linear = torch.nn.Linear(in_channels, in_channels, bias=False)
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         """Reset the parameters of the layer."""
         self.linear.reset_parameters()
 

--- a/topomodelx/nn/hypergraph/unigin_layer.py
+++ b/topomodelx/nn/hypergraph/unigin_layer.py
@@ -31,9 +31,9 @@ class UniGINLayer(torch.nn.Module):
         self,
         nn,
         in_channels,
-        eps=0.0,
-        train_eps=False,
-    ):
+        eps: float = 0.0,
+        train_eps: bool = False,
+    ) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.initial_eps = eps

--- a/topomodelx/nn/hypergraph/unisage_layer.py
+++ b/topomodelx/nn/hypergraph/unisage_layer.py
@@ -40,10 +40,10 @@ class UniSAGELayer(torch.nn.Module):
         self,
         in_channels,
         out_channels,
-        e_aggr="sum",
-        v_aggr="mean",
-        use_bn=False,
-    ):
+        e_aggr: str = "sum",
+        v_aggr: str = "mean",
+        use_bn: bool = False,
+    ) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -55,7 +55,7 @@ class UniSAGELayer(torch.nn.Module):
         self._validate_aggr(v_aggr)
         self._validate_aggr(e_aggr)
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.linear.reset_parameters()
         if self.bn is not None:

--- a/topomodelx/nn/simplicial/dist2cycle_layer.py
+++ b/topomodelx/nn/simplicial/dist2cycle_layer.py
@@ -11,7 +11,7 @@ class Dist2CycleLayer(torch.nn.Module):
     def __init__(
         self,
         channels,
-    ):
+    ) -> None:
         super().__init__()
         self.channels = channels
         # feature learning
@@ -20,7 +20,7 @@ class Dist2CycleLayer(torch.nn.Module):
         # need to support for other update functions like leaky relu
         # which is main for dist2Cycle
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         fc_nonlin = "relu"
         fc_alpha = 0.0

--- a/topomodelx/nn/simplicial/hsn_layer.py
+++ b/topomodelx/nn/simplicial/hsn_layer.py
@@ -32,7 +32,7 @@ class HSNLayer(torch.nn.Module):
     def __init__(
         self,
         channels,
-    ):
+    ) -> None:
         super().__init__()
         self.channels = channels
 
@@ -60,7 +60,7 @@ class HSNLayer(torch.nn.Module):
 
         self.aggr_on_nodes = Aggregation(aggr_func="sum", update_func="sigmoid")
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.conv_level1_0_to_0.reset_parameters()
         self.conv_level1_0_to_1.reset_parameters()

--- a/topomodelx/nn/simplicial/san_layer.py
+++ b/topomodelx/nn/simplicial/san_layer.py
@@ -25,8 +25,8 @@ class SANConv(Conv):
         in_channels,
         out_channels,
         p_filters,
-        initialization="xavier_uniform",
-    ):
+        initialization: str = "xavier_uniform",
+    ) -> None:
         super(Conv, self).__init__(
             att=True,
             initialization=initialization,
@@ -134,8 +134,8 @@ class SANLayer(torch.nn.Module):
         self,
         in_channels,
         out_channels,
-        num_filters_J=2,
-    ):
+        num_filters_J: int = 2,
+    ) -> None:
         super().__init__()
 
         self.in_channels = in_channels
@@ -152,7 +152,7 @@ class SANLayer(torch.nn.Module):
         # Harmonic convolution
         self.conv_har = Conv(in_channels, out_channels)
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.conv_down.reset_parameters()
         self.conv_up.reset_parameters()

--- a/topomodelx/nn/simplicial/sca_cmps_layer.py
+++ b/topomodelx/nn/simplicial/sca_cmps_layer.py
@@ -34,8 +34,8 @@ class SCACMPSLayer(torch.nn.Module):
         self,
         channels_list,
         complex_dim,
-        att=False,
-    ):
+        att: bool = False,
+    ) -> None:
         super().__init__()
         self.att = att
         self.dim = complex_dim
@@ -67,7 +67,7 @@ class SCACMPSLayer(torch.nn.Module):
             update_func="relu",
         )
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset parameters of each layer."""
         for layer in self.lap_layers:
             if isinstance(layer, Conv):

--- a/topomodelx/nn/simplicial/sccn_layer.py
+++ b/topomodelx/nn/simplicial/sccn_layer.py
@@ -47,9 +47,9 @@ class SCCNLayer(torch.nn.Module):
         self,
         channels,
         max_rank,
-        aggr_func="sum",
-        update_func="sigmoid",
-    ):
+        aggr_func: str = "sum",
+        update_func: str = "sigmoid",
+    ) -> None:
         super().__init__()
         self.channels = channels
         self.max_rank = max_rank
@@ -100,7 +100,7 @@ class SCCNLayer(torch.nn.Module):
             }
         )
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         for rank in self.convs_same_rank:
             self.convs_same_rank[rank].reset_parameters()

--- a/topomodelx/nn/simplicial/sccnn_layer.py
+++ b/topomodelx/nn/simplicial/sccnn_layer.py
@@ -79,10 +79,10 @@ class SCCNNLayer(torch.nn.Module):
         out_channels,
         conv_order,
         sc_order,
-        aggr_norm=False,
+        aggr_norm: bool = False,
         update_func=None,
-        initialization="xavier_normal",
-    ):
+        initialization: str = "xavier_normal",
+    ) -> None:
         super().__init__()
 
         in_channels_0, in_channels_1, in_channels_2 = in_channels
@@ -141,7 +141,7 @@ class SCCNNLayer(torch.nn.Module):
 
         self.reset_parameters()
 
-    def reset_parameters(self, gain=1.414):
+    def reset_parameters(self, gain: float = 1.414):
         r"""Reset learnable parameters.
 
         Notes

--- a/topomodelx/nn/simplicial/scconv_layer.py
+++ b/topomodelx/nn/simplicial/scconv_layer.py
@@ -19,7 +19,7 @@ class SCConvLayer(torch.nn.Module):
 
     """
 
-    def __init__(self, node_channels, edge_channels, face_channels):
+    def __init__(self, node_channels, edge_channels, face_channels) -> None:
         super().__init__()
 
         self.node_channels = node_channels
@@ -70,7 +70,7 @@ class SCConvLayer(torch.nn.Module):
         self.aggr_on_edges = Aggregation(aggr_func="sum", update_func="sigmoid")
         self.aggr_on_faces = Aggregation(aggr_func="sum", update_func="sigmoid")
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset parameters."""
         self.conv_0_to_0.reset_parameters()
         self.conv_0_to_1.reset_parameters()

--- a/topomodelx/nn/simplicial/scn2_layer.py
+++ b/topomodelx/nn/simplicial/scn2_layer.py
@@ -45,13 +45,13 @@ class SCN2Layer(torch.nn.Module):
         Dimension of input features on faces (2-cells).
     """
 
-    def __init__(self, in_channels_0, in_channels_1, in_channels_2):
+    def __init__(self, in_channels_0, in_channels_1, in_channels_2) -> None:
         super().__init__()
         self.conv_0_to_0 = Conv(in_channels=in_channels_0, out_channels=in_channels_0)
         self.conv_1_to_1 = Conv(in_channels=in_channels_1, out_channels=in_channels_1)
         self.conv_2_to_2 = Conv(in_channels=in_channels_2, out_channels=in_channels_2)
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.conv_0_to_0.reset_parameters()
         self.conv_1_to_1.reset_parameters()

--- a/topomodelx/nn/simplicial/scnn_layer.py
+++ b/topomodelx/nn/simplicial/scnn_layer.py
@@ -56,10 +56,10 @@ class SCNNLayer(torch.nn.Module):
         out_channels,
         conv_order_down,
         conv_order_up,
-        aggr_norm=False,
+        aggr_norm: bool = False,
         update_func=None,
-        initialization="xavier_uniform",
-    ):
+        initialization: str = "xavier_uniform",
+    ) -> None:
         super().__init__()
 
         self.in_channels = in_channels
@@ -81,7 +81,7 @@ class SCNNLayer(torch.nn.Module):
 
         self.reset_parameters()
 
-    def reset_parameters(self, gain=1.414):
+    def reset_parameters(self, gain: float = 1.414) -> None:
         r"""Reset learnable parameters.
 
         Notes

--- a/topomodelx/nn/simplicial/scone_layer.py
+++ b/topomodelx/nn/simplicial/scone_layer.py
@@ -48,7 +48,7 @@ class SCoNeLayer(torch.nn.Module):
         )
         self.aggr_on_edges = Aggregation("sum", update_func)
 
-    def reset_parameters(self, gain: float = 1.0):
+    def reset_parameters(self, gain: float = 1.0) -> None:
         """Reset learnable parameters."""
         torch.nn.init.xavier_uniform_(self.weight_0, gain=gain)
         torch.nn.init.xavier_uniform_(self.weight_1, gain=gain)

--- a/topomodelx/nn/simplicial/scone_layer_bis.py
+++ b/topomodelx/nn/simplicial/scone_layer_bis.py
@@ -28,7 +28,7 @@ class SCoNeLayer(torch.nn.Module):
         Initialization method.
     """
 
-    def __init__(self, channels):
+    def __init__(self, channels) -> None:
         super().__init__()
         self.channels = channels
 
@@ -52,7 +52,7 @@ class SCoNeLayer(torch.nn.Module):
 
         self.aggr_edges = Aggregation(aggr_func="sum", update_func="sigmoid")
 
-    def reset_parameters(self):
+    def reset_parameters(self) -> None:
         r"""Reset learnable parameters."""
         self.conv_level1.reset_parameters()
         self.conv_level2.reset_parameters()

--- a/topomodelx/utils/scatter.py
+++ b/topomodelx/utils/scatter.py
@@ -4,12 +4,10 @@ Adaptation of torch_scatter/scatter.py from:
 https://github.com/rusty1s/pytorch_scatter/blob/master/torch_scatter/scatter.py
 """
 
-from typing import Optional
-
 import torch
 
 
-def broadcast(src: torch.Tensor, other: torch.Tensor, dim: int):
+def broadcast(src: torch.Tensor, other: torch.Tensor, dim: int) -> torch.Tensor:
     """Broadcasts `src` to the shape of `other`."""
     if dim < 0:
         dim = other.dim() + dim
@@ -26,8 +24,8 @@ def scatter_sum(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: Optional[torch.Tensor] = None,
-    dim_size: Optional[int] = None,
+    out: torch.Tensor | None = None,
+    dim_size: int | None = None,
 ) -> torch.Tensor:
     """Add all values from the `src` tensor into `out` at the indices."""
     index = broadcast(index, src, dim)
@@ -49,8 +47,8 @@ def scatter_add(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: Optional[torch.Tensor] = None,
-    dim_size: Optional[int] = None,
+    out: torch.Tensor | None = None,
+    dim_size: int | None = None,
 ) -> torch.Tensor:
     """Add all values from the `src` tensor into `out` at the indices."""
     return scatter_sum(src, index, dim, out, dim_size)
@@ -60,8 +58,8 @@ def scatter_mean(
     src: torch.Tensor,
     index: torch.Tensor,
     dim: int = -1,
-    out: Optional[torch.Tensor] = None,
-    dim_size: Optional[int] = None,
+    out: torch.Tensor | None = None,
+    dim_size: int | None = None,
 ) -> torch.Tensor:
     """Compute the mean value of all values from the `src` tensor into `out`."""
     out = scatter_sum(src, index, dim, out, dim_size)
@@ -87,7 +85,7 @@ def scatter_mean(
 SCATTER_DICT = {"sum": scatter_sum, "mean": scatter_mean, "add": scatter_sum}
 
 
-def scatter(scatter):
+def scatter(scatter: str):
     """Return the scatter function."""
     if isinstance(scatter, str) and scatter in SCATTER_DICT:
         return SCATTER_DICT[scatter]


### PR DESCRIPTION
These have been automatically generated by `autotyping` and are by no means perfect. For example at certain places more specific `Literal` types instead of `str` could be used. This is, however, already a huge step in the right direction.

Along the way, this also fixed some documentation errors or moved to a more consistent documentation style.

See #174 