### PR TITLE
Simplicial: Add equations in docstrings of forward methods

### DIFF
--- a/topomodelx/nn/simplicial/dist2cycle_layer.py
+++ b/topomodelx/nn/simplicial/dist2cycle_layer.py
@@ -33,6 +33,19 @@ class Dist2CycleLayer(torch.nn.Module):
     def forward(self, x_e, Linv, adjacency):
         r"""Forward pass.
 
+        .. math::
+            \begin{align*}
+            &🟥 \quad m^{(1 \rightarrow 1)}\_{y \rightarrow x}  = (A \odot (I + L\downarrow)^+{xy}) \cdot h_{y}^{t,(1)}\cdot \Theta^t\\
+            &🟧 \quad m_x^{(1 \rightarrow 1)}  = \sum_{y \in \mathcal{L}\_\downarrow(x)} m_{y \rightarrow x}^{(1 \rightarrow 1)}\\
+            &🟩 \quad m_x^{(1)}  = m^{(1 \rightarrow 1)}_x\\
+            &🟦 \quad h_x^{t+1,(1)} = \sigma(m_{x}^{(1)})
+            \end{align*}
+
+        References
+        ----------
+        .. [TNN23] Equations of Topological Neural Networks.
+            https://github.com/awesome-tnns/awesome-tnns/
+
         Parameters
         ----------
         x: torch.Tensor, shape=[n_nodes, channels]

--- a/topomodelx/nn/simplicial/san_layer.py
+++ b/topomodelx/nn/simplicial/san_layer.py
@@ -51,7 +51,7 @@ class SANConv(Conv):
         self.reset_parameters()
 
     def forward(self, x_source, neighborhood):
-        """Forward pass.
+        r"""Forward pass.
 
         This implements message passing:
         - from source cells with input features `x_source`,
@@ -59,6 +59,22 @@ class SANConv(Conv):
         - to target cells, which are the same source cells.
 
         In practice, this will update the features on the target cells.
+        .. math::
+            \begin{align*}
+            &🟥 \quad m_{y \rightarrow \{z\} \rightarrow x}^{u,(1 \rightarrow 2 \rightarrow 1)}  = ((L_{\uparrow,1} \odot \operatorname{att}(h_z^{t,(2)}, h_y^{t,(1)}))^u)\_{xy} \cdot h_y^{t,(1)} \cdot \Theta^{t,u}\\
+            &🟥 \quad m_{y \rightarrow \{z\} \rightarrow x}^{d,(1 \rightarrow 0 \rightarrow 1)}  = ((L_{\downarrow,1} \odot \operatorname{att}(h_z^{t,(0)}, h_y^{t,(1)}))^d)\_{xy} \cdot h_y^{t,(1)} \cdot \Theta^{t,d}\\
+            &🟥 \quad m^{p,(1 \rightarrow 1)}\_{y \rightarrow x} = ((1-wH_1)^p)\_{xy} \cdot h_y^{t,(1)} \cdot \Theta^{t,p}\\
+            &🟧 \quad m_{x}^{u,(1 \rightarrow 2 \rightarrow 1)}  = \sum_{y \in \mathcal{L}\_\uparrow(x)} m_{y \rightarrow \{z\} \rightarrow x}^{u,(1 \rightarrow 2 \rightarrow 1)}\\
+            &🟧 \quad m_{x}^{d,(1 \rightarrow 0 \rightarrow 1)}  = \sum_{y \in \mathcal{L}\downarrow(X)} m_{y \rightarrow \{z\} \rightarrow x}^{d,(1 \rightarrow 0 \rightarrow 1)}\\
+            &🟧 \quad m^{p,(1 \rightarrow 1)}\_{x}  = m^{p,(1 \rightarrow 1)}\_{x \rightarrow x}\\
+            &🟩 \quad m_x^{(1)}  = \sum_{p=1}^P m_x^{p,(1 \rightarrow 1)} + \sum_{u=1}^{U} m_{x}^{u,(1 \rightarrow 2 \rightarrow 1)} + \sum_{d=1}^{D} m_{x}^{d,(1 \rightarrow 0 \rightarrow 1)}\\
+            &🟦 \quad h_x^{t+1, (1)} = \sigma(m_x^{(1)})
+            \end{align*}
+
+        References
+        ----------
+        .. [TNN23] Equations of Topological Neural Networks.
+            https://github.com/awesome-tnns/awesome-tnns/
 
         Parameters
         ----------

--- a/topomodelx/nn/simplicial/sccnn_layer.py
+++ b/topomodelx/nn/simplicial/sccnn_layer.py
@@ -232,6 +232,21 @@ class SCCNNLayer(torch.nn.Module):
     def forward(self, x_all, laplacian_all, incidence_all):
         r"""Forward computation.
 
+        .. math::
+            \begin{align*}
+            &🟥 \quad m_{y \rightarrow z}^{(0\rightarrow1)}  = B_1^T \cdot h_y^{t,(0)} \cdot \Theta^{t,(0 \rightarrow 1)}\\
+            &🟧 $\quad m_{z}^{(0\rightarrow1)}  = \frac{1}\sum_{y \in \mathcal{B}(z)} m_{y \rightarrow z}^{(0\rightarrow1)} \qquad \text{where} \sum \text{represents a mean.}\\
+            &🟥 $\quad m_{z \rightarrow x}^{(1 \rightarrow 0)} = B_1\odot att(m_{z \in \mathcal{C}(x)}^{(0\rightarrow1)}, h_x^{t,(0)}) \cdot m_z^{(0\rightarrow1)} \cdot \Theta^{t,(1 \rightarrow 0)}\\
+            &🟧 $\quad m_x^{(1\rightarrow0)}  = \sum_{z \in \mathcal{C}(x)} m_{z \rightarrow x}^{(1\rightarrow0)} \qquad \text{where} \sum \text{represents a mean.}\\
+            &🟩 \quad m_x^{(0)}  = m_x^{(1\rightarrow0)}\\
+            &🟦 \quad h_x^{t+1, (0)} = \Theta^{t, \text{update}} \cdot (h_x^{t,(0)}||m_x^{(0)})+b^{t, \text{update}}\\
+            \end{align*}
+
+        References
+        ----------
+        .. [TNN23] Equations of Topological Neural Networks.
+            https://github.com/awesome-tnns/awesome-tnns/
+
         Parameters
         ----------
         x_all : tuple (x_0,x_1,x_2)

--- a/topomodelx/nn/simplicial/scn2_layer.py
+++ b/topomodelx/nn/simplicial/scn2_layer.py
@@ -60,6 +60,20 @@ class SCN2Layer(torch.nn.Module):
     def forward(self, x_0, x_1, x_2, laplacian_0, laplacian_1, laplacian_2):
         r"""Forward pass.
 
+        .. math::
+            \begin{align*}
+            &🟥 \quad m^{(r \rightarrow r)}\_{y \rightarrow x}  = (2I + H_r)\_{{xy}} \cdot h_{y}^{t,(1)}\cdot \Theta^t\\
+            &🟧 \quad m_x^{(1 \rightarrow 1)}  = \sum_{y \in (\mathcal{L}\_\downarrow+\mathcal{L}\_\uparrow)(x)} m_{y \rightarrow x}^{(1 \rightarrow 1)}\\
+            &🟩 \quad m_x^{(1)}  = m^{(1 \rightarrow 1)}_x\\
+            &🟦 \quad h_x^{t+1,(1)} = \sigma(m_{x}^{(1)})
+            \end{align*}
+
+        References
+        ----------
+        .. [TNN23] Equations of Topological Neural Networks.
+            https://github.com/awesome-tnns/awesome-tnns/
+
+
         Parameters
         ----------
         x_0 : torch.Tensor, shape=[n_nodes, node_features]

--- a/topomodelx/nn/simplicial/scnn_layer.py
+++ b/topomodelx/nn/simplicial/scnn_layer.py
@@ -155,6 +155,26 @@ class SCNNLayer(torch.nn.Module):
     def forward(self, x, laplacian_down, laplacian_up):
         r"""Forward computation.
 
+        .. math::
+            \begin{align*}
+            &🟥 \quad m_{y \rightarrow \{z\} \rightarrow x}^{p,u,(1 \rightarrow 2 \rightarrow 1)}  = ((L_{\uparrow,1})^u)\_{xy} \cdot h_y^{t,(1)} \cdot (\alpha^{t, p, u} \cdot I)\\
+            &🟥 \quad m_{y \rightarrow \{z\} \rightarrow x}^{p,d,(1 \rightarrow 0 \rightarrow 1)} = ((L_{\downarrow,1})^d)\_{xy} \cdot h_y^{t,(1)} \cdot (\alpha^{t, p, d} \cdot I)\\
+            &🟥 \quad m^{(1 \rightarrow 1)}\_{x \rightarrow x} = \alpha \cdot h_x^{t, (1)}\\
+            &🟧 \quad m_{x}^{p,u,(1 \rightarrow 2 \rightarrow 1)}  = \sum_{y \in \mathcal{L}\_\uparrow(X)}m_{y \rightarrow \{z\} \rightarrow x}^{p,u,(1 \rightarrow 2 \rightarrow 1)}\\
+            &🟧 \quad m_{x}^{p,d,(1 \rightarrow 0 \rightarrow 1)} = \sum_{y \in \mathcal{L}\_\downarrow(X)}m_{y \rightarrow \{z\} \rightarrow x}^{p,d,(1 \rightarrow 0 \rightarrow 1)}\\
+            &🟧 \quad m^{(1 \rightarrow 1)}\_{x} = m^{(1 \rightarrow 1)}\_{x \rightarrow x}\\
+            &🟩 \quad m_x^{(1)}  = m_x^{(1 \rightarrow 1)} + \sum_{p=1}^P( \sum_{u=1}^{U} m_{x}^{p,u,(1 \rightarrow 2 \rightarrow 1)} + \sum_{d=1}^{D} m_{x}^{p,d,(1 \rightarrow 0 \rightarrow 1)})\\
+            &🟦 \quad h_x^{t+1, (1)} = \sigma(m_x^{(1)})
+            \end{align*}
+
+        References
+        ----------
+        .. Maosheng Yang et. al.
+        [SIMPLICIAL CONVOLUTIONAL NEURAL NETWORKS (2022)].
+        https://arxiv.org/pdf/2110.02585.pdf
+        .. [TNN23] Equations of Topological Neural Networks.
+            https://github.com/awesome-tnns/awesome-tnns/
+
         Parameters
         ----------
         x: torch.Tensor, shape=[n_simplex,in_channels]


### PR DESCRIPTION
Changes to address #167.

Note:
SCN2_layer (SCN2) does not seem to have equations in the awesome-tnns docs, closest I could match it with was Simplicial Convolutional Network, please correct me if that is wrong, will revert that.

Have also added references to https://github.com/awesome-tnns/awesome-tnns/, please suggest edits to references based on papers if required. 