### PR TITLE
Speed CI workflow: Divide tests into testing the codebase and testing the tutorials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1
+        test-type: ["codebase", "tutorials"]
 
     steps:
       - uses: actions/checkout@v3
@@ -57,9 +58,14 @@ jobs:
       - name: Typecheck [mypy]
         run: |
           mypy -p topomodelx
-      - name: Run tests [pytest]
+      - name: Run tests for codebase [pytest]
+        if : ${{matrix.test-folder == "codebase"}}
         run: |
-          pytest --cov --cov-report=xml:coverage.xml
+          pytest --cov --cov-report=xml:coverage.xml test/nn test/base test/utils
+      - name: Run tests for tutorials [pytest]
+        if : ${{matrix.test-folder == "tutorials"}}
+        run: |
+          pytest --cov --cov-report=xml:coverage.xml test/test_tutorials.py
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,9 @@ jobs:
       - name: Run tests for tutorials [pytest]
         if : ${{matrix.test-scope == 'tutorials'}}
         run: |
-          pytest --cov --cov-report=xml:coverage.xml test/test_tutorials.py
+          pytest test/test_tutorials.py
       - name: Upload coverage
+        if : ${{matrix.test-scope == 'codebase'}}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11"]
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1
-        test-type: ["codebase", "tutorials"]
+        test-scope: ["codebase", "tutorials"]
 
     steps:
       - uses: actions/checkout@v3
@@ -59,11 +59,11 @@ jobs:
         run: |
           mypy -p topomodelx
       - name: Run tests for codebase [pytest]
-        if : ${{matrix.test-folder == "codebase"}}
+        if : ${{matrix.test-scope == 'codebase'}}
         run: |
           pytest --cov --cov-report=xml:coverage.xml test/nn test/base test/utils
       - name: Run tests for tutorials [pytest]
-        if : ${{matrix.test-folder == "tutorials"}}
+        if : ${{matrix.test-scope == 'tutorials'}}
         run: |
           pytest --cov --cov-report=xml:coverage.xml test/test_tutorials.py
       - name: Upload coverage


### PR DESCRIPTION
Cache is allowed so that packages installed by pip can be reused.
Fail-fast is enabled to further speed-up the process.