### PR TITLE
Documentation cleanup

### DIFF
--- a/topomodelx/nn/cell/can.py
+++ b/topomodelx/nn/cell/can.py
@@ -120,14 +120,14 @@ class CAN(torch.nn.Module):
             Input features on the nodes (0-cells).
         x_1 : torch.Tensor, shape = (n_edges, in_channels_1)
             Input features on the edges (1-cells).
-        lower_neighborhood : tensor, shape = (-, -)
+        lower_neighborhood : torch.Tensor, shape = (-, -)
             Lower Neighbourhood matrix.
-        upper_neighborhood : tensor, shape = (-, -)
+        upper_neighborhood : torch.Tensor, shape = (-, -)
             Upper neighbourhood matrix.
 
         Returns
         -------
-        output tensor
+        torch.Tensor
         """
         if hasattr(self, "lift_layer"):
             x_1 = self.lift_layer(x_0, neighborhood_0_to_0, x_1)

--- a/topomodelx/nn/cell/ccxn.py
+++ b/topomodelx/nn/cell/ccxn.py
@@ -65,9 +65,9 @@ class CCXN(torch.nn.Module):
             Input features on the nodes (0-cells).
         x_1 : torch.Tensor, shape = (n_edges, in_channels_1)
             Input features on the edges (1-cells).
-        neighborhood_0_to_0 : tensor, shape = (n_nodes, n_nodes)
+        neighborhood_0_to_0 : torch.Tensor, shape = (n_nodes, n_nodes)
             Adjacency matrix of rank 0 (up).
-        neighborhood_1_to_2 : tensor, shape = (n_faces, n_edges)
+        neighborhood_1_to_2 : torch.Tensor, shape = (n_faces, n_edges)
             Transpose of boundary matrix of rank 2.
         x_2 : torch.Tensor, shape = (n_faces, in_channels_2)
             Input features on the faces (2-cells).
@@ -75,7 +75,7 @@ class CCXN(torch.nn.Module):
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for layer in self.layers:

--- a/topomodelx/nn/cell/cwn.py
+++ b/topomodelx/nn/cell/cwn.py
@@ -81,16 +81,16 @@ class CWN(torch.nn.Module):
             Input features on the edges (1-cells).
         x_2 : torch.Tensor, shape = (n_faces, in_channels_2)
             Input features on the faces (2-cells).
-        neighborhood_1_to_1 : tensor, shape = (n_edges, n_edges)
+        neighborhood_1_to_1 : torch.Tensor, shape = (n_edges, n_edges)
             Upper-adjacency matrix of rank 1.
-        neighborhood_2_to_1 : tensor, shape = (n_edges, n_faces)
+        neighborhood_2_to_1 : torch.Tensor, shape = (n_edges, n_faces)
             Boundary matrix of rank 2.
-        neighborhood_0_to_1 : tensor, shape = (n_edges, n_nodes)
+        neighborhood_0_to_1 : torch.Tensor, shape = (n_edges, n_nodes)
             Coboundary matrix of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         x_0 = F.elu(self.proj_0(x_0))

--- a/topomodelx/nn/hypergraph/dhgcn.py
+++ b/topomodelx/nn/hypergraph/dhgcn.py
@@ -45,12 +45,12 @@ class DHGCN(torch.nn.Module):
 
         Parameters
         ----------
-        x_0 : tensor, shape = (n_nodes, node_channels)
+        x_0 : torch.Tensor, shape = (n_nodes, node_channels)
             Edge features.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for layer in self.layers:

--- a/topomodelx/nn/hypergraph/hnhn.py
+++ b/topomodelx/nn/hypergraph/hnhn.py
@@ -56,7 +56,7 @@ class HNHN(torch.nn.Module):
         x_1 : torch.Tensor, shape = (n_nodes, channels_edge)
             Hyperedge features.
 
-        incidence_1 : tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
@@ -120,7 +120,7 @@ class HNHNNetwork(torch.nn.Module):
             shape = [n_nodes, channels_edge]
             Hyperedge features.
 
-        incidence_1 : tensor
+        incidence_1 : torch.Tensor
             shape = [n_nodes, n_edges]
             Boundary matrix of rank 1.
 

--- a/topomodelx/nn/hypergraph/hypergat.py
+++ b/topomodelx/nn/hypergraph/hypergat.py
@@ -40,16 +40,16 @@ class HyperGAT(torch.nn.Module):
 
         Parameters
         ----------
-        x_1 : tensor
+        x_1 : torch.Tensor
             shape = (n_edges, channels_edge)
             Edge features.
 
-        incidence_1 : tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for layer in self.layers:

--- a/topomodelx/nn/hypergraph/hypersage.py
+++ b/topomodelx/nn/hypergraph/hypersage.py
@@ -44,15 +44,15 @@ class HyperSAGE(torch.nn.Module):
 
         Parameters
         ----------
-        x: tensor, shape = (n_nodes, features_nodes)
+        x: torch.Tensor, shape = (n_nodes, features_nodes)
             Edge features.
 
-        incidence: tensor, shape = (n_nodes, n_edges)
+        incidence: torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for layer in self.layers:

--- a/topomodelx/nn/hypergraph/unigcn.py
+++ b/topomodelx/nn/hypergraph/unigcn.py
@@ -43,15 +43,15 @@ class UniGCN(torch.nn.Module):
 
         Parameters
         ----------
-        x_1 : tensor, shape = (n_edges, channels_edge)
+        x_1 : torch.Tensor, shape = (n_edges, channels_edge)
             Edge features.
 
-        incidence_1 : tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for layer in self.layers:

--- a/topomodelx/nn/hypergraph/unigin.py
+++ b/topomodelx/nn/hypergraph/unigin.py
@@ -50,15 +50,15 @@ class UniGIN(torch.nn.Module):
 
         Parameters
         ----------
-        x_0 : tensor, shape = (n_nodes, in_channels_node)
+        x_0 : torch.Tensor, shape = (n_nodes, in_channels_node)
             Edge features.
 
-        incidence_1 : tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         x_0 = self.inp_embed(x_0)

--- a/topomodelx/nn/hypergraph/unisage.py
+++ b/topomodelx/nn/hypergraph/unisage.py
@@ -43,15 +43,15 @@ class UniSAGE(torch.nn.Module):
 
         Parameters
         ----------
-        x_1 : tensor, shape = (n_edges, channels_edge)
+        x_1 : torch.Tensor, shape = (n_edges, channels_edge)
             Edge features.
 
-        incidence_1 : tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for layer in self.layers:

--- a/topomodelx/nn/simplicial/dist2cycle.py
+++ b/topomodelx/nn/simplicial/dist2cycle.py
@@ -33,12 +33,12 @@ class Dist2Cycle(torch.nn.Module):
 
         Parameters
         ----------
-        x_1e : tensor, shape = (n_nodes, channels)
+        x_1e : torch.Tensor, shape = (n_nodes, channels)
             Node features.
 
         Returns
         -------
-        _ : tensor, shape = (n_nodes, 2)
+        torch.Tensor, shape = (n_nodes, 2)
             One-hot labels assigned to nodes.
 
         """

--- a/topomodelx/nn/simplicial/hsn.py
+++ b/topomodelx/nn/simplicial/hsn.py
@@ -33,18 +33,18 @@ class HSN(torch.nn.Module):
 
         Parameters
         ----------
-        x_0 : tensor, shape = (n_nodes, channels)
+        x_0 : torch.Tensor, shape = (n_nodes, channels)
             Node features.
 
-        incidence_1 : tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
-        adjacency_0 : tensor, shape = (n_nodes, n_nodes)
+        adjacency_0 : torch.Tensor, shape = (n_nodes, n_nodes)
             Adjacency matrix (up) of rank 0.
 
         Returns
         -------
-        _ : tensor, shape = (n_nodes, 2)
+        torch.Tensor, shape = (n_nodes, 2)
             One-hot labels assigned to nodes.
 
         """

--- a/topomodelx/nn/simplicial/san.py
+++ b/topomodelx/nn/simplicial/san.py
@@ -84,12 +84,12 @@ class SAN(torch.nn.Module):
 
         Parameters
         ----------
-        L : tensor, shape = (n_edges, n_edges)
+        L : torch.Tensor, shape = (n_edges, n_edges)
             Hodge laplacian of rank 1.
 
         Returns
         -------
-        _ : tensor, shape = (n_edges, n_edges)
+        torch.Tensor, shape = (n_edges, n_edges)
             Projection matrix.
         """
         projection_mat = (
@@ -103,19 +103,19 @@ class SAN(torch.nn.Module):
 
         Parameters
         ----------
-        x : tensor, shape = (n_nodes, channels_in)
+        x : torch.Tensor, shape = (n_nodes, channels_in)
             Node features.
 
-        laplacian_up : tensor, shape = (n_edges, n_edges)
+        laplacian_up : torch.Tensor, shape = (n_edges, n_edges)
             Upper laplacian of rank 1.
 
-        Ld : tensor, shape = (n_edges, n_edges)
+        Ld : torch.Tensor, shape = (n_edges, n_edges)
             Down laplacian of rank 1.
 
 
         Returns
         -------
-        _ : tensor, shape = (n_nodes, 2)
+        torch.Tensor, shape = (n_nodes, 2)
             One-hot labels assigned to edges.
 
         """

--- a/topomodelx/nn/simplicial/sca_cmps.py
+++ b/topomodelx/nn/simplicial/sca_cmps.py
@@ -60,7 +60,7 @@ class SCACMPS(torch.nn.Module):
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         for i in range(self.n_layers):

--- a/topomodelx/nn/simplicial/sccn.py
+++ b/topomodelx/nn/simplicial/sccn.py
@@ -58,7 +58,7 @@ class SCCN(torch.nn.Module):
 
         Returns
         -------
-        _ : tensor
+        torch.Tensor
             If n_classes > 2:
                 shape = (n_nodes, n_classes)
                 Logits assigned to each node.

--- a/topomodelx/nn/simplicial/sccnn.py
+++ b/topomodelx/nn/simplicial/sccnn.py
@@ -92,7 +92,7 @@ class SCCNN(torch.nn.Module):
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
         """
         x_0, x_1, x_2 = x_all
@@ -214,7 +214,7 @@ class SCCNNComplex(torch.nn.Module):
 
         Returns
         -------
-        tensor, shape = (n_nodes, 2)
+        torch.Tensor, shape = (n_nodes, 2)
             One-hot labels assigned to nodes.
         """
         x_0, x_1, x_2 = x_all

--- a/topomodelx/nn/simplicial/sccnn_layer.py
+++ b/topomodelx/nn/simplicial/sccnn_layer.py
@@ -18,8 +18,8 @@ class SCCNNLayer(torch.nn.Module):
         Convolution order of the simplicial filters.
         To avoid too many parameters, we consider them to be the same.
 
-    Example
-    -------
+    Examples
+    --------
     Here we provide an example of pseudocode for SCCNN layer in an SC
     of order two
     input X_0: [n_nodes, in_channels]

--- a/topomodelx/nn/simplicial/scconv.py
+++ b/topomodelx/nn/simplicial/scconv.py
@@ -96,7 +96,7 @@ class SCConv(torch.nn.Module):
 
         Returns
         -------
-        _ : tensor, shape = (1)
+        torch.Tensor, shape = (1)
             Label assigned to whole complex.
 
         """

--- a/topomodelx/nn/simplicial/scn2.py
+++ b/topomodelx/nn/simplicial/scn2.py
@@ -45,12 +45,12 @@ class SCN2(torch.nn.Module):
 
         Parameters
         ----------
-        x_0 : tensor, shape = (n_nodes, channels)
+        x_0 : torch.Tensor, shape = (n_nodes, channels)
             Node features.
 
         Returns
         -------
-        _ : tensor, shape = (n_nodes, 2)
+        torch.Tensor, shape = (n_nodes, 2)
             One-hot labels assigned to nodes.
 
         """

--- a/topomodelx/nn/simplicial/scnn.py
+++ b/topomodelx/nn/simplicial/scnn.py
@@ -72,17 +72,17 @@ class SCNN(torch.nn.Module):
 
         Parameters
         ----------
-        x : tensor, shape = (n_simplices, channels)
+        x : torch.Tensor, shape = (n_simplices, channels)
             Tensor of features node/edge/face.
-        laplacian_down : tensor, shape = (n_simplices, n_simplices)
+        laplacian_down : torch.Tensor, shape = (n_simplices, n_simplices)
             Down Laplacian.
             For node features, laplacian_down = None.
-        laplacian_up: tensor, shape = (n_edges, n_nodes)
+        laplacian_up: torch.Tensor, shape = (n_edges, n_nodes)
             Up Laplacian.
 
         Returns
         -------
-        one_dimensional_cells_mean : tensor, shape = (n_simplices, 1)
+        torch.Tensor, shape = (n_simplices, 1)
             Mean on one-dimensional cells.
         """
         for layer in self.layers:

--- a/topomodelx/nn/simplicial/scnn_layer.py
+++ b/topomodelx/nn/simplicial/scnn_layer.py
@@ -23,8 +23,8 @@ class SCNNLayer(torch.nn.Module):
         - down: for the lower convolutions.
         - up: for the upper convolutions.
 
-    Example
-    -------
+    Examples
+    --------
     Here we provide an example of pseudocode for SCNN layer
     input X: [n_simplices, in_channels]
     Lap_down, Lap_up: [n_simplices, n_simplices]


### PR DESCRIPTION
- For singular return values (i.e., anything but tuples), the return value does not have a name. In particular the construct `_ : type` is weird and does not follow NumPy's documentation guide.
- Its `torch.Tensor` and not just `tensor`, in particular not in lower case (which may reference to the function `torch.tensor` but not to the class `torch.Tensor`).