### PR TITLE
Adding util method to directly convert sparse matrix to torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ plugins = "numpy.typing.mypy_plugin"
 
 [[tool.mypy.overrides]]
 module = [
-    "torch_cluster.*","networkx.*","scipy.spatial","toponetx.classes.simplicial_complex"
+    "torch_cluster.*","networkx.*","scipy.spatial","scipy.sparse","toponetx.classes.simplicial_complex"
 ]
 ignore_missing_imports = true
 

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -7,7 +7,7 @@ from topomodelx.utils.sparse import from_sparse
 
 
 def test_from_sparse():
-    # test numerical matching
+    # test matrix matches numerically
     test_matrix = sparse._csc.csc_matrix(np.random.rand(100, 100))
     a = torch.from_numpy(test_matrix.todense()).to_sparse()
     b = from_sparse(test_matrix)

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -1,7 +1,6 @@
 """Tests from_sparse utility function."""
 
 import numpy as np
-import pytest
 import torch
 from scipy import sparse
 
@@ -25,10 +24,3 @@ def test_from_sparse():
     b = from_sparse(test_matrix)
 
     torch.testing.assert_close(a.to_dense(), b.to_dense(), check_dtype=False)
-
-
-def test_fail_on_wrong_type():
-    """Tests from_sparse raises exception with non sparse input."""
-    with pytest.raises(ValueError):
-        test_matrix = np.random.rand(100, 100)
-        from_sparse(test_matrix)

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -1,3 +1,5 @@
+"""Tests from_sparse utility function."""
+
 import numpy as np
 import pytest
 import torch
@@ -7,7 +9,8 @@ from topomodelx.utils.sparse import from_sparse
 
 
 def test_from_sparse():
-    # test matrix matches numerically
+    """Tests from_sparse matches sparse -> dense -> sparse."""
+    # test values matche
     test_matrix = sparse._csc.csc_matrix(np.random.rand(100, 100))
     a = torch.from_numpy(test_matrix.todense()).to_sparse()
     b = from_sparse(test_matrix)
@@ -29,6 +32,7 @@ def test_from_sparse():
 
 
 def test_fail_on_wrong_type():
+    """Tests from_sparse raises exception with non sparse input."""
     with pytest.raises(ValueError):
         test_matrix = np.random.rand(100, 100)
-        res = from_sparse(test_matrix)
+        from_sparse(test_matrix)

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -15,9 +15,7 @@ def test_from_sparse():
     a = torch.from_numpy(test_matrix.todense()).to_sparse()
     b = from_sparse(test_matrix)
 
-    assert torch.equal(
-        a.to_dense().type(torch.float32), b.to_dense().type(torch.float32)
-    )
+    torch.testing.assert_close(a.to_dense(), b.to_dense(), check_dtype=False)
 
     # test on larger dimension
     test_matrix = sparse.csc_matrix(
@@ -26,9 +24,7 @@ def test_from_sparse():
     a = torch.from_numpy(test_matrix.todense()).to_sparse()
     b = from_sparse(test_matrix)
 
-    assert torch.equal(
-        a.to_dense().type(torch.float32), b.to_dense().type(torch.float32)
-    )
+    torch.testing.assert_close(a.to_dense(), b.to_dense(), check_dtype=False)
 
 
 def test_fail_on_wrong_type():

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+import torch
+from scipy import sparse
+
+from topomodelx.utils.sparse import from_sparse
+
+
+def test_from_sparse():
+    # test numerical matching
+    test_matrix = sparse._csc.csc_matrix(np.random.rand(100, 100))
+    a = torch.from_numpy(test_matrix.todense()).to_sparse()
+    b = from_sparse(test_matrix)
+
+    assert torch.equal(
+        a.to_dense().type(torch.float32), b.to_dense().type(torch.float32)
+    )
+
+    # test on larger dimension
+    test_matrix = sparse.csc_matrix(
+        ([3, 4, 5, -3.2], ([0, 1, 1, 200], [2, 0, 2, 500])), shape=(2000, 3000)
+    )
+    a = torch.from_numpy(test_matrix.todense()).to_sparse()
+    b = from_sparse(test_matrix)
+
+    assert torch.equal(
+        a.to_dense().type(torch.float32), b.to_dense().type(torch.float32)
+    )
+
+
+def test_fail_on_wrong_type():
+    with pytest.raises(ValueError):
+        test_matrix = np.random.rand(100, 100)
+        res = from_sparse(test_matrix)

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -1,28 +1,29 @@
+"""Utils for more efficient sparse matrix casting to torch."""
+
 import numpy as np
 import scipy
 import torch
 
 
 def from_sparse(data: scipy.sparse._csc.csc_matrix, dense=False):
-    """Converts sparse input data directly to torch sparse coo format
+    """Convert sparse input data directly to torch sparse coo format.
 
     Parameters
     ----------
     data : scipy.sparse._csc.csc_matrix
-        Input n_dimensional data
+        Input n_dimensional data.
 
     Returns
     -------
     torch.sparse_coo, same shape as data
         input data converted to tensor.
     """
-
     if not isinstance(data, scipy.sparse._csc.csc_matrix):
         raise ValueError(
             f"Expected Data type scipy.sparse._csc.csc_matrix, found {type(data)}"
         )
 
-    # cast from csc_matrix to coo format
+    # cast from csc_matrix to coo format for compatibility
     coo = data.tocoo()
 
     v = torch.FloatTensor(coo.data)

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -1,0 +1,36 @@
+import numpy as np
+import scipy
+import torch
+
+
+def from_sparse(data: scipy.sparse._csc.csc_matrix, dense=False):
+    """Converts sparse input data directly to torch sparse coo format
+
+    Parameters
+    ----------
+    data : scipy.sparse._csc.csc_matrix
+        Input n_dimensional data
+
+    Returns
+    -------
+    torch.sparse_coo, same shape as data
+        input data converted to tensor.
+    """
+
+    if not isinstance(data, scipy.sparse._csc.csc_matrix):
+        raise ValueError(
+            f"Expected Data type scipy.sparse._csc.csc_matrix, found {type(data)}"
+        )
+
+    # Cast from csc_matrix to coo format
+    coo = data.tocoo()
+
+    v = torch.FloatTensor(coo.data)
+    i = torch.LongTensor(np.vstack((coo.row, coo.col)))
+
+    out = torch.sparse_coo_tensor(i, v, coo.shape)
+
+    if dense:
+        return out.to_dense()
+
+    return out

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -1,11 +1,11 @@
 """Utils for more efficient sparse matrix casting to torch."""
 
 import numpy as np
-import scipy
 import torch
+from scipy.sparse import _csc
 
 
-def from_sparse(data: scipy.sparse._csc.csc_matrix):
+def from_sparse(data: _csc.csc_matrix):
     """Convert sparse input data directly to torch sparse coo format.
 
     Parameters
@@ -18,9 +18,9 @@ def from_sparse(data: scipy.sparse._csc.csc_matrix):
     torch.sparse_coo, same shape as data
         input data converted to tensor.
     """
-    if not isinstance(data, scipy.sparse._csc.csc_matrix):
+    if not isinstance(data, _csc.csc_matrix):
         raise ValueError(
-            f"Expected Data type scipy.sparse._csc.csc_matrix, found {type(data)}"
+            f"Expected Data type sparse._csc.csc_matrix, found {type(data)}"
         )
 
     # cast from csc_matrix to coo format for compatibility

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -18,11 +18,6 @@ def from_sparse(data: _csc.csc_matrix):
     torch.sparse_coo, same shape as data
         input data converted to tensor.
     """
-    if not isinstance(data, _csc.csc_matrix):
-        raise ValueError(
-            f"Expected Data type sparse._csc.csc_matrix, found {type(data)}"
-        )
-
     # cast from csc_matrix to coo format for compatibility
     coo = data.tocoo()
 

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -5,7 +5,7 @@ import scipy
 import torch
 
 
-def from_sparse(data: scipy.sparse._csc.csc_matrix, dense=False):
+def from_sparse(data: scipy.sparse._csc.csc_matrix):
     """Convert sparse input data directly to torch sparse coo format.
 
     Parameters
@@ -29,9 +29,4 @@ def from_sparse(data: scipy.sparse._csc.csc_matrix, dense=False):
     v = torch.FloatTensor(coo.data)
     i = torch.LongTensor(np.vstack((coo.row, coo.col)))
 
-    out = torch.sparse_coo_tensor(i, v, coo.shape)
-
-    if dense:
-        return out.to_dense()
-
-    return out
+    return torch.sparse_coo_tensor(i, v, coo.shape)

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -26,7 +26,7 @@ def from_sparse(data: _csc.csc_matrix):
     # cast from csc_matrix to coo format for compatibility
     coo = data.tocoo()
 
-    v = torch.FloatTensor(coo.data)
-    i = torch.LongTensor(np.vstack((coo.row, coo.col)))
+    values = torch.FloatTensor(coo.data)
+    indices = torch.LongTensor(np.vstack((coo.row, coo.col)))
 
-    return torch.sparse_coo_tensor(i, v, coo.shape)
+    return torch.sparse_coo_tensor(indices, values, coo.shape)

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -5,7 +5,7 @@ import torch
 from scipy.sparse import _csc
 
 
-def from_sparse(data: _csc.csc_matrix):
+def from_sparse(data: _csc.csc_matrix) -> torch.Tensor:
     """Convert sparse input data directly to torch sparse coo format.
 
     Parameters

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -22,7 +22,7 @@ def from_sparse(data: scipy.sparse._csc.csc_matrix, dense=False):
             f"Expected Data type scipy.sparse._csc.csc_matrix, found {type(data)}"
         )
 
-    # Cast from csc_matrix to coo format
+    # cast from csc_matrix to coo format
     coo = data.tocoo()
 
     v = torch.FloatTensor(coo.data)


### PR DESCRIPTION
Here's a PR with proposed solution for https://github.com/pyt-team/TopoModelX/issues/209. I tried few variations and this seems to be the most efficient. It doesn't seem to affect speed on smaller dimensions as in [here](https://github.com/pyt-team/TopoModelX/blob/main/tutorials/cell/can_train.ipynb) but definitely on a larger sparse matrix:

```
$test_matrix =  coo_matrix(([3,4,5,-3.2], ([0,1,1,200], [2,0,2,500])), shape=(2000,3000))

# current way
$ %timeit torch.from_numpy(test_matrix.todense()).to_sparse().to_dense()
5.63 ms ± 66.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# with proposed util function
$ %timeit to_torch_coo(test_matrix)
24.2 µs ± 129 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Since I'm still getting familiar with the repo, I'm not sure where's the best place for this function so would love some feedback.