### PR TITLE
add scipy.sparse to mypy ignored modules in toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ plugins = "numpy.typing.mypy_plugin"
 
 [[tool.mypy.overrides]]
 module = [
-    "torch_cluster.*","networkx.*","scipy.spatial","toponetx.classes.simplicial_complex"
+    "torch_cluster.*","networkx.*","scipy.spatial","scipy.sparse","toponetx.classes.simplicial_complex"
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Seems that PR #233 is blocked due to scipy stubs being missing.  This should fix the issue by adding scipy.sparse to list of modules to ignore missing imports.