### PR TITLE
Replace old sparse -> dense -> sparse with new from_sparse method

### DIFF
--- a/test/nn/simplicial/test_san.py
+++ b/test/nn/simplicial/test_san.py
@@ -6,6 +6,7 @@ import torch
 from toponetx.classes import SimplicialComplex
 
 from topomodelx.nn.simplicial.san import SAN
+from topomodelx.utils.sparse import from_sparse
 
 
 class TestSAN:
@@ -32,9 +33,7 @@ class TestSAN:
             simplicial_complex.add_simplex(simplex)
         x_1 = torch.randn(35, 2)
         x_0 = torch.randn(15, 2)
-        incidence_0_1 = torch.from_numpy(
-            simplicial_complex.incidence_matrix(1).todense()
-        ).to_sparse()
+        incidence_0_1 = from_sparse(simplicial_complex.incidence_matrix(1))
         x = x_1 + torch.sparse.mm(incidence_0_1.T, x_0)
         in_channels = x.shape[-1]
         hidden_channels = 16
@@ -45,12 +44,8 @@ class TestSAN:
             out_channels=out_channels,
             n_layers=1,
         )
-        laplacian_down_1 = torch.from_numpy(
-            simplicial_complex.down_laplacian_matrix(rank=1).todense()
-        ).to_sparse()
-        laplacian_up_1 = torch.from_numpy(
-            simplicial_complex.up_laplacian_matrix(rank=1).todense()
-        ).to_sparse()
+        laplacian_down_1 = from_sparse(simplicial_complex.down_laplacian_matrix(rank=1))
+        laplacian_up_1 = from_sparse(simplicial_complex.up_laplacian_matrix(rank=1))
 
         assert torch.any(
             torch.isclose(

--- a/test/nn/simplicial/test_sca_cmps.py
+++ b/test/nn/simplicial/test_sca_cmps.py
@@ -6,6 +6,7 @@ import torch
 from toponetx.classes import SimplicialComplex
 
 from topomodelx.nn.simplicial.sca_cmps import SCACMPS
+from topomodelx.utils.sparse import from_sparse
 
 
 class TestSCA:
@@ -38,10 +39,10 @@ class TestSCA:
         down_lap2 = simplicial_complex.down_laplacian_matrix(rank=2)
         incidence_1t = simplicial_complex.incidence_matrix(rank=1).T
         incidence_2t = simplicial_complex.incidence_matrix(rank=2).T
-        down_lap1 = torch.from_numpy(down_lap1.todense()).to_sparse()
-        down_lap2 = torch.from_numpy(down_lap2.todense()).to_sparse()
-        incidence_1t = torch.from_numpy(incidence_1t.todense()).to_sparse()
-        incidence_2t = torch.from_numpy(incidence_2t.todense()).to_sparse()
+        down_lap1 = from_sparse(down_lap1)
+        down_lap2 = from_sparse(down_lap2)
+        incidence_1t = from_sparse(incidence_1t)
+        incidence_2t = from_sparse(incidence_2t)
         channels_list = [x_0.shape[-1], x_1.shape[-1], x_2.shape[-1]]
         complex_dim = 3
         model = SCACMPS(

--- a/test/nn/simplicial/test_sccn.py
+++ b/test/nn/simplicial/test_sccn.py
@@ -6,6 +6,7 @@ import torch
 from toponetx.classes import SimplicialComplex
 
 from topomodelx.nn.simplicial.sccn import SCCN
+from topomodelx.utils.sparse import from_sparse
 
 
 class TestSCCN:
@@ -38,7 +39,7 @@ class TestSCCN:
         max_rank = 2
 
         def sparse_to_torch(X):
-            return torch.from_numpy(X.todense()).to_sparse()
+            return from_sparse(X)
 
         incidences = {
             f"rank_{r}": sparse_to_torch(simplicial_complex.incidence_matrix(rank=r))

--- a/test/nn/simplicial/test_sccnn.py
+++ b/test/nn/simplicial/test_sccnn.py
@@ -6,6 +6,7 @@ import torch
 from toponetx.classes import SimplicialComplex
 
 from topomodelx.nn.simplicial.sccnn import SCCNN
+from topomodelx.utils.sparse import from_sparse
 
 
 class TestSCCNN:
@@ -46,12 +47,12 @@ class TestSCCNN:
         laplacian_up_1 = simplicial_complex.up_laplacian_matrix(rank=1)
         laplacian_2 = simplicial_complex.hodge_laplacian_matrix(rank=2, weight=True)
 
-        incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()
-        incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()
-        laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()
-        laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()
-        laplacian_up_1 = torch.from_numpy(laplacian_up_1.todense()).to_sparse()
-        laplacian_2 = torch.from_numpy(laplacian_2.todense()).to_sparse()
+        incidence_1 = from_sparse(incidence_1)
+        incidence_2 = from_sparse(incidence_2)
+        laplacian_0 = from_sparse(laplacian_0)
+        laplacian_down_1 = from_sparse(laplacian_down_1)
+        laplacian_up_1 = from_sparse(laplacian_up_1)
+        laplacian_2 = from_sparse(laplacian_2)
         conv_order = 2
         intermediate_channels_all = (16, 16, 16)
         out_channels_all = intermediate_channels_all

--- a/test/nn/simplicial/test_scn2.py
+++ b/test/nn/simplicial/test_scn2.py
@@ -6,6 +6,7 @@ import torch
 from toponetx.classes import SimplicialComplex
 
 from topomodelx.nn.simplicial.scn2 import SCN2
+from topomodelx.utils.sparse import from_sparse
 
 
 class TestSCN2:
@@ -38,9 +39,9 @@ class TestSCN2:
         laplacian_1 = simplicial_complex.normalized_laplacian_matrix(rank=1)
         laplacian_2 = simplicial_complex.normalized_laplacian_matrix(rank=2)
 
-        laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()
-        laplacian_1 = torch.from_numpy(laplacian_1.todense()).to_sparse()
-        laplacian_2 = torch.from_numpy(laplacian_2.todense()).to_sparse()
+        laplacian_0 = from_sparse(laplacian_0)
+        laplacian_1 = from_sparse(laplacian_1)
+        laplacian_2 = from_sparse(laplacian_2)
         in_channels_0 = x_0.shape[1]
         in_channels_1 = x_1.shape[1]
         in_channels_2 = x_2.shape[1]

--- a/test/nn/simplicial/test_scnn.py
+++ b/test/nn/simplicial/test_scnn.py
@@ -7,6 +7,7 @@ import torch
 from toponetx.classes import SimplicialComplex
 
 from topomodelx.nn.simplicial.scnn import SCNN
+from topomodelx.utils.sparse import from_sparse
 
 
 class TestSCNN:
@@ -41,12 +42,12 @@ class TestSCNN:
         laplacian_up_1 = simplicial_complex.up_laplacian_matrix(rank=1)
         laplacian_2 = simplicial_complex.hodge_laplacian_matrix(rank=2, weight=True)
 
-        incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()
-        incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()
-        laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()
-        laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()
-        laplacian_up_1 = torch.from_numpy(laplacian_up_1.todense()).to_sparse()
-        laplacian_2 = torch.from_numpy(laplacian_2.todense()).to_sparse()
+        incidence_1 = from_sparse(incidence_1)
+        incidence_2 = from_sparse(incidence_2)
+        laplacian_0 = from_sparse(laplacian_0)
+        laplacian_down_1 = from_sparse(laplacian_down_1)
+        laplacian_up_1 = from_sparse(laplacian_up_1)
+        laplacian_2 = from_sparse(laplacian_2)
         conv_order_down = 2
         conv_order_up = 2
         intermediate_channels = 4

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -24,4 +24,4 @@ def from_sparse(data: _csc.csc_matrix) -> torch.Tensor:
     values = torch.FloatTensor(coo.data)
     indices = torch.LongTensor(np.vstack((coo.row, coo.col)))
 
-    return torch.sparse_coo_tensor(indices, values, coo.shape)
+    return torch.sparse_coo_tensor(indices, values, coo.shape).coalesce()

--- a/tutorials/cell/can_train.ipynb
+++ b/tutorials/cell/can_train.ipynb
@@ -250,7 +250,7 @@
     "\n",
     "for cell_complex in cc_list:\n",
     "    adjacency_0 = cell_complex.adjacency_matrix(rank=0)\n",
-    "    adjacency_0 = from_sparse(adjacency_0)\n",
+    "    adjacency_0 = torch.from_numpy(adjacency_0.todense()).to_sparse()\n",
     "    adjacency_0_list.append(adjacency_0)\n",
     "\n",
     "    lower_neighborhood_t = cell_complex.down_laplacian_matrix(rank=1)\n",

--- a/tutorials/cell/can_train.ipynb
+++ b/tutorials/cell/can_train.ipynb
@@ -124,7 +124,8 @@
     "import torch.nn.functional as F\n",
     "\n",
     "\n",
-    "from topomodelx.nn.cell.can import CAN"
+    "from topomodelx.nn.cell.can import CAN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -249,18 +250,16 @@
     "\n",
     "for cell_complex in cc_list:\n",
     "    adjacency_0 = cell_complex.adjacency_matrix(rank=0)\n",
-    "    adjacency_0 = torch.from_numpy(adjacency_0.todense()).to_sparse()\n",
+    "    adjacency_0 = from_sparse(adjacency_0)\n",
     "    adjacency_0_list.append(adjacency_0)\n",
     "\n",
     "    lower_neighborhood_t = cell_complex.down_laplacian_matrix(rank=1)\n",
-    "    lower_neighborhood_t = torch.from_numpy(lower_neighborhood_t.todense()).to_sparse()\n",
+    "    lower_neighborhood_t = from_sparse(lower_neighborhood_t)\n",
     "    lower_neighborhood_list.append(lower_neighborhood_t)\n",
     "\n",
     "    try:\n",
     "        upper_neighborhood_t = cell_complex.up_laplacian_matrix(rank=1)\n",
-    "        upper_neighborhood_t = torch.from_numpy(\n",
-    "            upper_neighborhood_t.todense()\n",
-    "        ).to_sparse()\n",
+    "        upper_neighborhood_t = from_sparse(upper_neighborhood_t)\n",
     "    except:\n",
     "        upper_neighborhood_t = np.zeros(\n",
     "            (lower_neighborhood_t.shape[0], lower_neighborhood_t.shape[0])\n",

--- a/tutorials/cell/ccxn_train.ipynb
+++ b/tutorials/cell/ccxn_train.ipynb
@@ -65,7 +65,8 @@
     "import toponetx.datasets as datasets\n",
     "\n",
     "\n",
-    "from topomodelx.nn.cell.ccxn import CCXN"
+    "from topomodelx.nn.cell.ccxn import CCXN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -194,8 +195,8 @@
     "\n",
     "    incidence_2_t = cell_complex.incidence_matrix(rank=2).T\n",
     "    adjacency_0 = cell_complex.adjacency_matrix(rank=0)\n",
-    "    incidence_2_t = torch.from_numpy(incidence_2_t.todense()).to_sparse()\n",
-    "    adjacency_0 = torch.from_numpy(adjacency_0.todense()).to_sparse()\n",
+    "    incidence_2_t = from_sparse(incidence_2_t)\n",
+    "    adjacency_0 = from_sparse(adjacency_0)\n",
     "    incidence_2_t_list.append(incidence_2_t)\n",
     "    adjacency_0_list.append(adjacency_0)"
    ]

--- a/tutorials/cell/cwn_train.ipynb
+++ b/tutorials/cell/cwn_train.ipynb
@@ -61,7 +61,8 @@
     "\n",
     "import toponetx.datasets as datasets\n",
     "\n",
-    "from topomodelx.nn.cell.cwn import CWN"
+    "from topomodelx.nn.cell.cwn import CWN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -222,9 +223,9 @@
     "    adjacency_1 = cell_complex.adjacency_matrix(rank=1)\n",
     "    incidence_1_t = cell_complex.incidence_matrix(rank=1).T\n",
     "\n",
-    "    incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()\n",
-    "    adjacency_1 = torch.from_numpy(adjacency_1.todense()).to_sparse()\n",
-    "    incidence_1_t = torch.from_numpy(incidence_1_t.todense()).to_sparse()\n",
+    "    incidence_2 = from_sparse(incidence_2)\n",
+    "    adjacency_1 = from_sparse(adjacency_1)\n",
+    "    incidence_1_t = from_sparse(incidence_1_t)\n",
     "\n",
     "    incidence_2_list.append(incidence_2)\n",
     "    adjacency_1_list.append(adjacency_1)\n",

--- a/tutorials/hypergraph/allset_train.ipynb
+++ b/tutorials/hypergraph/allset_train.ipynb
@@ -59,7 +59,8 @@
     "from sklearn.model_selection import train_test_split\n",
     "import toponetx.datasets as datasets\n",
     "\n",
-    "from topomodelx.nn.hypergraph.allset import AllSet"
+    "from topomodelx.nn.hypergraph.allset import AllSet\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -196,7 +197,7 @@
     "incidence_1_list = []\n",
     "for simplex in simplexes:\n",
     "    incidence_1 = simplex.incidence_matrix(rank=1, signed=False)\n",
-    "    # incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    # incidence_1 = from_sparse(incidence_1)\n",
     "    # incidence_1_list.append(incidence_1)\n",
     "    hg = simplex.to_hypergraph()\n",
     "    hg_list.append(hg)\n",
@@ -205,7 +206,7 @@
     "# Extract hypergraphs incident matrices from collected hypergraphs\n",
     "for hg in hg_list:\n",
     "    incidence_1 = hg.incidence_matrix()\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
     "    incidence_1_list.append(incidence_1)"
    ]
   },

--- a/tutorials/hypergraph/allset_transformer_train.ipynb
+++ b/tutorials/hypergraph/allset_transformer_train.ipynb
@@ -91,6 +91,7 @@
     "from sklearn.model_selection import train_test_split\n",
     "\n",
     "from topomodelx.nn.hypergraph.allset_transformer import AllSetTransformer\n",
+    "from topomodelx.utils.sparse import from_sparse\n",
     "\n",
     "# %load_ext autoreload\n",
     "# %autoreload 2"
@@ -236,7 +237,7 @@
     "# Extract hypergraphs incident matrices from collected hypergraphs\n",
     "for hg in hg_list:\n",
     "    incidence_1 = hg.incidence_matrix()\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
     "    incidence_1_list.append(incidence_1)"
    ]
   },

--- a/tutorials/hypergraph/dhgcn_train.ipynb
+++ b/tutorials/hypergraph/dhgcn_train.ipynb
@@ -26,7 +26,8 @@
     "from sklearn.model_selection import train_test_split\n",
     "\n",
     "import toponetx.datasets as datasets\n",
-    "from topomodelx.nn.hypergraph.dhgcn import DHGCN"
+    "from topomodelx.nn.hypergraph.dhgcn import DHGCN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -204,7 +205,7 @@
     "incidence_1_list = []\n",
     "for simplex in simplexes:\n",
     "    incidence_1 = simplex.incidence_matrix(rank=1, signed=False)\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
     "    incidence_1_list.append(incidence_1)\n",
     "    hg = simplex.to_hypergraph()\n",
     "    hg_list.append(hg)"

--- a/tutorials/hypergraph/hnhn_train.ipynb
+++ b/tutorials/hypergraph/hnhn_train.ipynb
@@ -44,7 +44,8 @@
     "import toponetx.datasets.graph as graph\n",
     "from topomodelx.nn.hypergraph.hnhn_layer import HNHNLayer\n",
     "import matplotlib.pyplot as plt\n",
-    "from topomodelx.nn.hypergraph.hnhn import HNHN, HNHNNetwork"
+    "from topomodelx.nn.hypergraph.hnhn import HNHN, HNHNNetwork\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -119,7 +120,7 @@
    ],
    "source": [
     "incidence_1 = dataset_sim.incidence_matrix(rank=1, signed=False)\n",
-    "incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "incidence_1 = from_sparse(incidence_1)\n",
     "print(f\"The incidence matrix B1 has shape: {incidence_1.shape}.\")"
    ]
   },

--- a/tutorials/hypergraph/hypergat_train.ipynb
+++ b/tutorials/hypergraph/hypergat_train.ipynb
@@ -59,7 +59,8 @@
     "import toponetx.datasets as datasets\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from topomodelx.nn.hypergraph.hypergat import HyperGAT"
+    "from topomodelx.nn.hypergraph.hypergat import HyperGAT\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -177,7 +178,7 @@
     "# Extract hypergraphs incident matrices from collected hypergraphs\n",
     "for hg in hg_list:\n",
     "    incidence_1 = hg.incidence_matrix()\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
     "    incidence_1_list.append(incidence_1)"
    ]
   },

--- a/tutorials/hypergraph/hypersage_train.ipynb
+++ b/tutorials/hypergraph/hypersage_train.ipynb
@@ -46,7 +46,8 @@
     "import toponetx.datasets as datasets\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from topomodelx.nn.hypergraph.hypersage import HyperSAGE"
+    "from topomodelx.nn.hypergraph.hypersage import HyperSAGE\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -164,7 +165,7 @@
     "# Extract hypergraphs incident matrices from collected hypergraphs\n",
     "for hg in hg_list:\n",
     "    incidence_1 = hg.incidence_matrix()\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
     "    incidence_1_list.append(incidence_1)"
    ]
   },

--- a/tutorials/hypergraph/unigin_train.ipynb
+++ b/tutorials/hypergraph/unigin_train.ipynb
@@ -12,7 +12,8 @@
     "from torch_geometric.datasets import TUDataset\n",
     "from torch_geometric.utils.convert import to_networkx\n",
     "from toponetx.classes.simplicial_complex import SimplicialComplex\n",
-    "from topomodelx.nn.hypergraph.unigin import UniGIN"
+    "from topomodelx.nn.hypergraph.unigin import UniGIN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -58,7 +59,7 @@
     "incidence_1_list = []\n",
     "for hg in hg_list:\n",
     "    incidence_1 = hg.incidence_matrix()\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
     "    incidence_1_list.append(incidence_1)"
    ]
   },

--- a/tutorials/simplicial/dist2cycle_train.ipynb
+++ b/tutorials/simplicial/dist2cycle_train.ipynb
@@ -38,6 +38,7 @@
     "import toponetx.datasets.graph as graph\n",
     "\n",
     "from topomodelx.nn.simplicial.dist2cycle import Dist2Cycle\n",
+    "from topomodelx.utils.sparse import from_sparse\n",
     "import numpy.linalg as npla"
    ]
   },
@@ -101,8 +102,8 @@
     "incidence_1 = dataset.incidence_matrix(rank=1)\n",
     "adjacency_0 = dataset.adjacency_matrix(rank=0)\n",
     "\n",
-    "incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
-    "adjacency_0 = torch.from_numpy(adjacency_0.todense()).to_sparse()\n",
+    "incidence_1 = from_sparse(incidence_1)\n",
+    "adjacency_0 = from_sparse(adjacency_0)\n",
     "\n",
     "print(f\"The incidence matrix B1 has shape: {incidence_1.shape}.\")\n",
     "print(f\"The adjacency matrix A0 has shape: {adjacency_0.shape}.\")"

--- a/tutorials/simplicial/hsn_train.ipynb
+++ b/tutorials/simplicial/hsn_train.ipynb
@@ -42,7 +42,8 @@
     "\n",
     "import toponetx.datasets.graph as graph\n",
     "\n",
-    "from topomodelx.nn.simplicial.hsn import HSN"
+    "from topomodelx.nn.simplicial.hsn import HSN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -103,8 +104,8 @@
     "incidence_1 = dataset.incidence_matrix(rank=1)\n",
     "adjacency_0 = dataset.adjacency_matrix(rank=0)\n",
     "\n",
-    "incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
-    "adjacency_0 = torch.from_numpy(adjacency_0.todense()).to_sparse()\n",
+    "incidence_1 = from_sparse(incidence_1)\n",
+    "adjacency_0 = from_sparse(adjacency_0)\n",
     "\n",
     "print(f\"The incidence matrix B1 has shape: {incidence_1.shape}.\")\n",
     "print(f\"The adjacency matrix A0 has shape: {adjacency_0.shape}.\")"

--- a/tutorials/simplicial/san_train.ipynb
+++ b/tutorials/simplicial/san_train.ipynb
@@ -84,6 +84,7 @@
     "from torch_geometric.utils.convert import to_networkx\n",
     "\n",
     "from topomodelx.nn.simplicial.san import SAN\n",
+    "from topomodelx.utils.sparse import from_sparse\n",
     "\n",
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -201,18 +202,14 @@
     "simplex_order_k = 1\n",
     "# Down laplacian\n",
     "try:\n",
-    "    laplacian_down = torch.from_numpy(\n",
-    "        dataset.down_laplacian_matrix(rank=simplex_order_k).todense()\n",
-    "    ).to_sparse()\n",
+    "    laplacian_down = from_sparse(dataset.down_laplacian_matrix(rank=simplex_order_k))\n",
     "except ValueError:\n",
     "    laplacian_down = torch.zeros(\n",
     "        (dataset.shape[simplex_order_k], dataset.shape[simplex_order_k])\n",
     "    ).to_sparse()\n",
     "# Up laplacian\n",
     "try:\n",
-    "    laplacian_up = torch.from_numpy(\n",
-    "        dataset.up_laplacian_matrix(rank=simplex_order_k).todense()\n",
-    "    ).to_sparse()\n",
+    "    laplacian_up = from_sparse(dataset.up_laplacian_matrix(rank=simplex_order_k))\n",
     "except ValueError:\n",
     "    laplacian_up = torch.zeros(\n",
     "        (dataset.shape[simplex_order_k], dataset.shape[simplex_order_k])\n",
@@ -288,7 +285,7 @@
    },
    "outputs": [],
    "source": [
-    "incidence_0_1 = torch.from_numpy(dataset.incidence_matrix(1).todense()).to_sparse()"
+    "incidence_0_1 = from_sparse(dataset.incidence_matrix(1))"
    ]
   },
   {

--- a/tutorials/simplicial/sca_cmps_train.ipynb
+++ b/tutorials/simplicial/sca_cmps_train.ipynb
@@ -34,7 +34,8 @@
     "import toponetx.datasets as datasets\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
-    "from topomodelx.nn.simplicial.sca_cmps import SCACMPS"
+    "from topomodelx.nn.simplicial.sca_cmps import SCACMPS\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -159,10 +160,10 @@
     "    incidence_1_t = sc.incidence_matrix(rank=1).T\n",
     "    incidence_2_t = sc.incidence_matrix(rank=2).T\n",
     "\n",
-    "    laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()\n",
-    "    laplacian_down_2 = torch.from_numpy(laplacian_down_2.todense()).to_sparse()\n",
-    "    incidence_1_t = torch.from_numpy(incidence_1_t.todense()).to_sparse()\n",
-    "    incidence_2_t = torch.from_numpy(incidence_2_t.todense()).to_sparse()\n",
+    "    laplacian_down_1 = from_sparse(laplacian_down_1)\n",
+    "    laplacian_down_2 = from_sparse(laplacian_down_2)\n",
+    "    incidence_1_t = from_sparse(incidence_1_t)\n",
+    "    incidence_2_t = from_sparse(incidence_2_t)\n",
     "\n",
     "    laplacian_down_1_list.append(laplacian_down_1)\n",
     "    laplacian_down_2_list.append(laplacian_down_2)\n",

--- a/tutorials/simplicial/sccn_train.ipynb
+++ b/tutorials/simplicial/sccn_train.ipynb
@@ -44,7 +44,8 @@
     "\n",
     "import toponetx.datasets.graph as graph\n",
     "\n",
-    "from topomodelx.nn.simplicial.sccn import SCCN"
+    "from topomodelx.nn.simplicial.sccn import SCCN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -131,7 +132,7 @@
    ],
    "source": [
     "def sparse_to_torch(X):\n",
-    "    return torch.from_numpy(X.todense()).to_sparse()\n",
+    "    return from_sparse(X)\n",
     "\n",
     "\n",
     "incidences = {\n",

--- a/tutorials/simplicial/sccnn_train.ipynb
+++ b/tutorials/simplicial/sccnn_train.ipynb
@@ -67,7 +67,8 @@
     "import numpy as np\n",
     "from sklearn.model_selection import train_test_split\n",
     "import toponetx.datasets as datasets\n",
-    "from topomodelx.nn.simplicial.sccnn import SCCNN, SCCNNComplex"
+    "from topomodelx.nn.simplicial.sccnn import SCCNN, SCCNNComplex\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -164,12 +165,12 @@
     "    laplacian_up_1 = simplex.up_laplacian_matrix(rank=1)\n",
     "    laplacian_2 = simplex.hodge_laplacian_matrix(rank=2)\n",
     "\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
-    "    incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()\n",
-    "    laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()\n",
-    "    laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()\n",
-    "    laplacian_up_1 = torch.from_numpy(laplacian_up_1.todense()).to_sparse()\n",
-    "    laplacian_2 = torch.from_numpy(laplacian_2.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
+    "    incidence_2 = from_sparse(incidence_2)\n",
+    "    laplacian_0 = from_sparse(laplacian_0)\n",
+    "    laplacian_down_1 = from_sparse(laplacian_down_1)\n",
+    "    laplacian_up_1 = from_sparse(laplacian_up_1)\n",
+    "    laplacian_2 = from_sparse(laplacian_2)\n",
     "\n",
     "    incidence_1_list.append(incidence_1)\n",
     "    incidence_2_list.append(incidence_2)\n",
@@ -526,14 +527,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()\n",
-    "laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()\n",
-    "laplacian_up_1 = torch.from_numpy(laplacian_up_1.todense()).to_sparse()\n",
-    "laplacian_down_2 = torch.from_numpy(laplacian_down_2.todense()).to_sparse()\n",
-    "laplacian_up_2 = torch.from_numpy(laplacian_up_2.todense()).to_sparse()\n",
+    "laplacian_0 = from_sparse(laplacian_0)\n",
+    "laplacian_down_1 = from_sparse(laplacian_down_1)\n",
+    "laplacian_up_1 = from_sparse(laplacian_up_1)\n",
+    "laplacian_down_2 = from_sparse(laplacian_down_2)\n",
+    "laplacian_up_2 = from_sparse(laplacian_up_2)\n",
     "\n",
-    "incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
-    "incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()"
+    "incidence_1 = from_sparse(incidence_1)\n",
+    "incidence_2 = from_sparse(incidence_2)"
    ]
   },
   {

--- a/tutorials/simplicial/scconv_train.ipynb
+++ b/tutorials/simplicial/scconv_train.ipynb
@@ -77,7 +77,8 @@
     "\n",
     "from topomodelx.base.aggregation import Aggregation\n",
     "\n",
-    "from topomodelx.nn.simplicial.scconv import SCConv"
+    "from topomodelx.nn.simplicial.scconv import SCConv\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -355,14 +356,14 @@
     "    #     down_laplacian_1 = simplex.down_laplacian_matrix(rank=1)  #1\n",
     "    #     down_laplacian_2 = simplex.down_laplacian_matrix(rank=2)  #2\n",
     "    #\n",
-    "    #     incidence_1 = torch.from_numpy(B1.todense()).to_sparse()\n",
-    "    #     incidence_2 = torch.from_numpy(B2.todense()).to_sparse()\n",
+    "    #     incidence_1 = from_sparse(B1)\n",
+    "    #     incidence_2 = from_sparse(B2)\n",
     "    #\n",
-    "    #     up_laplacian_1 = torch.from_numpy(up_laplacian_1.todense()).to_sparse()\n",
-    "    #     up_laplacian_2 = torch.from_numpy(up_laplacian_2.todense()).to_sparse()\n",
+    "    #     up_laplacian_1 = from_sparse(up_laplacian_1)\n",
+    "    #     up_laplacian_2 = from_sparse(up_laplacian_2)\n",
     "    #\n",
-    "    #     down_laplacian_1 = torch.from_numpy(down_laplacian_1.todense()).to_sparse()\n",
-    "    #     down_laplacian_2 = torch.from_numpy(down_laplacian_2.todense()).to_sparse()\n",
+    "    #     down_laplacian_1 = from_sparse(down_laplacian_1)\n",
+    "    #     down_laplacian_2 = from_sparse(down_laplacian_2)\n",
     "    #\n",
     "    #     incidence_1_list.append(incidence_1)\n",
     "    #     incidence_2_list.append(incidence_2)\n",

--- a/tutorials/simplicial/scn2_train.ipynb
+++ b/tutorials/simplicial/scn2_train.ipynb
@@ -30,7 +30,8 @@
     "import toponetx.datasets as datasets\n",
     "\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from topomodelx.nn.simplicial.scn2 import SCN2"
+    "from topomodelx.nn.simplicial.scn2 import SCN2\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -141,9 +142,9 @@
     "    laplacian_1 = x.normalized_laplacian_matrix(rank=1)\n",
     "    laplacian_2 = x.normalized_laplacian_matrix(rank=2)\n",
     "\n",
-    "    laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()\n",
-    "    laplacian_1 = torch.from_numpy(laplacian_1.todense()).to_sparse()\n",
-    "    laplacian_2 = torch.from_numpy(laplacian_2.todense()).to_sparse()\n",
+    "    laplacian_0 = from_sparse(laplacian_0)\n",
+    "    laplacian_1 = from_sparse(laplacian_1)\n",
+    "    laplacian_2 = from_sparse(laplacian_2)\n",
     "\n",
     "    laplacian_0s.append(laplacian_0)\n",
     "    laplacian_1s.append(laplacian_1)\n",

--- a/tutorials/simplicial/scnn_train.ipynb
+++ b/tutorials/simplicial/scnn_train.ipynb
@@ -68,7 +68,8 @@
     "\n",
     "import toponetx.datasets as datasets\n",
     "\n",
-    "from topomodelx.nn.simplicial.scnn import SCNN"
+    "from topomodelx.nn.simplicial.scnn import SCNN\n",
+    "from topomodelx.utils.sparse import from_sparse"
    ]
   },
   {
@@ -162,12 +163,12 @@
     "    laplacian_up_1 = simplex.up_laplacian_matrix(rank=1)\n",
     "    laplacian_2 = simplex.hodge_laplacian_matrix(rank=2)\n",
     "\n",
-    "    incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
-    "    incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()\n",
-    "    laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()\n",
-    "    laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()\n",
-    "    laplacian_up_1 = torch.from_numpy(laplacian_up_1.todense()).to_sparse()\n",
-    "    laplacian_2 = torch.from_numpy(laplacian_2.todense()).to_sparse()\n",
+    "    incidence_1 = from_sparse(incidence_1)\n",
+    "    incidence_2 = from_sparse(incidence_2)\n",
+    "    laplacian_0 = from_sparse(laplacian_0)\n",
+    "    laplacian_down_1 = from_sparse(laplacian_down_1)\n",
+    "    laplacian_up_1 = from_sparse(laplacian_up_1)\n",
+    "    laplacian_2 = from_sparse(laplacian_2)\n",
     "\n",
     "    incidence_1_list.append(incidence_1)\n",
     "    incidence_2_list.append(incidence_2)\n",
@@ -404,9 +405,9 @@
    ],
    "source": [
     "incidence_1 = dataset.incidence_matrix(rank=1)\n",
-    "incidence_1 = torch.from_numpy(incidence_1.todense()).to_sparse()\n",
+    "incidence_1 = from_sparse(incidence_1)\n",
     "incidence_2 = dataset.incidence_matrix(rank=2)\n",
-    "incidence_2 = torch.from_numpy(incidence_2.todense()).to_sparse()\n",
+    "incidence_2 = from_sparse(incidence_2)\n",
     "print(f\"The incidence matrix B1 has shape: {incidence_1.shape}.\")\n",
     "print(f\"The incidence matrix B2 has shape: {incidence_2.shape}.\")"
    ]
@@ -431,11 +432,11 @@
     "laplacian_down_2 = dataset.down_laplacian_matrix(rank=2)\n",
     "laplacian_up_2 = dataset.up_laplacian_matrix(rank=2)\n",
     "\n",
-    "laplacian_0 = torch.from_numpy(laplacian_0.todense()).to_sparse()\n",
-    "laplacian_down_1 = torch.from_numpy(laplacian_down_1.todense()).to_sparse()\n",
-    "laplacian_up_1 = torch.from_numpy(laplacian_up_1.todense()).to_sparse()\n",
-    "laplacian_down_2 = torch.from_numpy(laplacian_down_2.todense()).to_sparse()\n",
-    "laplacian_up_2 = torch.from_numpy(laplacian_up_2.todense()).to_sparse()"
+    "laplacian_0 = from_sparse(laplacian_0)\n",
+    "laplacian_down_1 = from_sparse(laplacian_down_1)\n",
+    "laplacian_up_1 = from_sparse(laplacian_up_1)\n",
+    "laplacian_down_2 = from_sparse(laplacian_down_2)\n",
+    "laplacian_up_2 = from_sparse(laplacian_up_2)"
    ]
   },
   {


### PR DESCRIPTION
Replaces all sparse torch casting to new method `from_sparse` except in 1 example where there's an issue #236 that's been documented. 