### PR TITLE
Simplicial checks

### DIFF
--- a/test/nn/simplicial/test_sca_cmps.py
+++ b/test/nn/simplicial/test_sca_cmps.py
@@ -56,7 +56,9 @@ class TestSCA:
         incidence_t_list = [incidence_1t, incidence_2t]
         forward_pass = model(x_list, down_lap_list, incidence_t_list)
         assert torch.any(
-            torch.isclose(forward_pass, torch.tensor([1.9269, 1.4873]), rtol=1e-02)
+            torch.isclose(
+                forward_pass[0][0], torch.tensor([1.9269, 1.4873]), rtol=1e-02
+            )
         )
 
     def test_reset_parameters(self):

--- a/test/nn/simplicial/test_sca_cmps.py
+++ b/test/nn/simplicial/test_sca_cmps.py
@@ -46,9 +46,8 @@ class TestSCA:
         channels_list = [x_0.shape[-1], x_1.shape[-1], x_2.shape[-1]]
         complex_dim = 3
         model = SCACMPS(
-            channels_list=channels_list,
+            in_channels_all=channels_list,
             complex_dim=complex_dim,
-            n_classes=1,
             n_layers=3,
             att=False,
         )
@@ -57,7 +56,7 @@ class TestSCA:
         incidence_t_list = [incidence_1t, incidence_2t]
         forward_pass = model(x_list, down_lap_list, incidence_t_list)
         assert torch.any(
-            torch.isclose(forward_pass, torch.tensor([-4.8042]), rtol=1e-02)
+            torch.isclose(forward_pass, torch.tensor([1.9269, 1.4873]), rtol=1e-02)
         )
 
     def test_reset_parameters(self):
@@ -65,7 +64,6 @@ class TestSCA:
         model = SCACMPS(
             [2, 2, 2],
             2,
-            n_classes=1,
             n_layers=3,
             att=False,
         )

--- a/test/nn/simplicial/test_scconv.py
+++ b/test/nn/simplicial/test_scconv.py
@@ -1,0 +1,90 @@
+"""Unit tests for SCCNN Model."""
+import itertools
+import random
+
+import torch
+from toponetx.classes import SimplicialComplex
+
+from topomodelx.nn.simplicial.scconv import SCConv
+from topomodelx.utils.sparse import from_sparse
+
+
+class TestSCConv:
+    """Unit tests for the SCConv model class."""
+
+    def test_forward(self):
+        """Test the forward method of SCConv."""
+        faces = 14
+        node_creation = 17
+        nodes_per_face = 3
+        seed_value = 42
+        random.seed(seed_value)
+        torch.manual_seed(seed_value)
+        # Create a random cell complex of cells with length 3
+        all_combinations = list(
+            itertools.combinations(
+                [x for x in range(1, node_creation + 1)], nodes_per_face
+            )
+        )
+        random.shuffle(all_combinations)
+        selected_combinations = all_combinations[:faces]
+        simplicial_complex = SimplicialComplex()
+        for simplex in selected_combinations:
+            simplicial_complex.add_simplex(simplex)
+        # Some nodes might not be selected at all in the combinations above
+        x_0 = torch.randn(simplicial_complex.shape[0], 2)
+        x_1 = torch.randn(simplicial_complex.shape[1], 2)
+        x_2 = torch.randn(faces, 2)
+
+        incidence_1_norm = from_sparse(simplicial_complex.incidence_matrix(1))
+        incidence_1 = from_sparse(simplicial_complex.coincidence_matrix(1))
+        incidence_2_norm = from_sparse(simplicial_complex.incidence_matrix(2))
+        incidence_2 = from_sparse(simplicial_complex.coincidence_matrix(2))
+        adjacency_up_0_norm = from_sparse(simplicial_complex.up_laplacian_matrix(0))
+        adjacency_up_1_norm = from_sparse(simplicial_complex.up_laplacian_matrix(1))
+        adjacency_down_1_norm = from_sparse(simplicial_complex.down_laplacian_matrix(1))
+        adjacency_down_2_norm = from_sparse(simplicial_complex.down_laplacian_matrix(2))
+
+        in_channels = x_0.shape[1]
+        n_layers = 2
+        model = SCConv(
+            node_channels=in_channels,
+            n_layers=n_layers,
+        )
+
+        with torch.no_grad():
+            forward_pass = model(
+                x_0,
+                x_1,
+                x_2,
+                incidence_1,
+                incidence_1_norm,
+                incidence_2,
+                incidence_2_norm,
+                adjacency_up_0_norm,
+                adjacency_up_1_norm,
+                adjacency_down_1_norm,
+                adjacency_down_2_norm,
+            )
+        assert torch.any(
+            torch.isclose(
+                forward_pass[0][0],
+                torch.tensor(
+                    [
+                        0.8847,
+                        0.9963,
+                    ]
+                ),
+                rtol=1e-02,
+            )
+        )
+
+    def test_reset_parameters(self):
+        """Test the reset_parameters method of SCConv."""
+        model = SCConv(4, 2)
+        for layer in model.children():
+            if hasattr(layer, "reset_parameters"):
+                layer.reset_parameters()
+        for module in model.modules():
+            if hasattr(module, "reset_parameters"):
+                module.reset_parameters()

--- a/test/nn/simplicial/test_scconv_layer.py
+++ b/test/nn/simplicial/test_scconv_layer.py
@@ -20,13 +20,13 @@ class TestSCConvLayer:
         x_0 = torch.randn(n_nodes, node_channels)
         x_1 = torch.randn(n_edges, edge_channels)
         x_2 = torch.randn(n_faces, face_channels)
-        incidence_1 = torch.randint(0, 2, (n_nodes, n_edges)).float()
+        incidence_1 = torch.randint(0, 2, (n_nodes, n_edges)).float().T
         # incidence_1_norm = torch.randint(0, 2, (n_nodes, n_edges)).float()
-        incidence_1_norm = torch.randint(0, 2, (n_edges, n_nodes)).float()
+        incidence_1_norm = torch.randint(0, 2, (n_edges, n_nodes)).float().T
 
-        incidence_2 = torch.randint(0, 2, (n_edges, n_faces)).float()
+        incidence_2 = torch.randint(0, 2, (n_edges, n_faces)).float().T
         # incidence_2_norm = torch.randint(0, 2, (n_edges, n_faces)).float()
-        incidence_2_norm = torch.randint(0, 2, (n_faces, n_edges)).float()
+        incidence_2_norm = torch.randint(0, 2, (n_faces, n_edges)).float().T
 
         adjacency_up_0_norm = torch.randint(0, 2, (n_nodes, n_nodes)).float()
         adjacency_up_1_norm = torch.randint(0, 2, (n_edges, n_edges)).float()

--- a/topomodelx/nn/simplicial/sca_cmps.py
+++ b/topomodelx/nn/simplicial/sca_cmps.py
@@ -1,7 +1,6 @@
 """SCA with CMPS."""
 import torch
 
-from topomodelx.base.aggregation import Aggregation
 from topomodelx.nn.simplicial.sca_cmps_layer import SCACMPSLayer
 
 
@@ -10,12 +9,10 @@ class SCACMPS(torch.nn.Module):
 
     Parameters
     ----------
-    channels_list : list[int]
+    in_channels_all : list[int]
         Dimension of features on each node, edge, simplex, tetahedron,... respectively
     complex_dim : int
         Highest dimension of simplicial complex feature being trained on.
-    n_classes : int
-        Dimension to which the complex embeddings will be projected.
     n_layers : int, default = 2
         Amount of message passing layers.
     att : bool
@@ -24,37 +21,28 @@ class SCACMPS(torch.nn.Module):
 
     def __init__(
         self,
-        channels_list,
+        in_channels_all,
         complex_dim,
-        n_classes,
         n_layers=2,
         att=False,
     ):
         super().__init__()
         self.n_layers = n_layers
-        self.channels_list = channels_list
-        self.n_classes = n_classes
+        self.in_channels_all = in_channels_all
 
         layers = []
         for _ in range(n_layers):
-            layers.append(SCACMPSLayer(channels_list, complex_dim, att))
+            layers.append(SCACMPSLayer(in_channels_all, complex_dim, att))
 
         self.layers = torch.nn.ModuleList(layers)
-        self.lin0 = torch.nn.Linear(channels_list[0], n_classes)
-        self.lin1 = torch.nn.Linear(channels_list[1], n_classes)
-        self.lin2 = torch.nn.Linear(channels_list[2], n_classes)
-        self.aggr = Aggregation(
-            aggr_func="mean",
-            update_func="sigmoid",
-        )
 
-    def forward(self, x_list, laplacian_down_list, incidence_t_list):
+    def forward(self, x, laplacian_down_list, incidence_t_list):
         """Forward computation through layers, then linear layers, then avg pooling.
 
         Parameters
         ----------
-        x_list : list[torch.Tensor]
-            List of tensor inputs for each dimension of the complex (nodes, edges, etc.).
+        x : list[torch.Tensor]
+            Tensor inputs for each dimension of the complex (nodes, edges, etc.).
         laplacian_down_list : list[torch.Tensor]
             List of the down laplacian matrix for each dimension in the complex starting at edges.
         incidence_t_list : list[torch.Tensor]
@@ -66,21 +54,6 @@ class SCACMPS(torch.nn.Module):
             Label assigned to whole complex.
         """
         for i in range(self.n_layers):
-            x_list = self.layers[i](x_list, laplacian_down_list, incidence_t_list)
+            x = self.layers[i](x, laplacian_down_list, incidence_t_list)
 
-        x_0 = self.lin0(x_list[0])
-        x_1 = self.lin1(x_list[1])
-        x_2 = self.lin2(x_list[2])
-
-        two_dimensional_cells_mean = torch.nanmean(x_2, dim=0)
-        two_dimensional_cells_mean[torch.isnan(two_dimensional_cells_mean)] = 0
-        one_dimensional_cells_mean = torch.nanmean(x_1, dim=0)
-        one_dimensional_cells_mean[torch.isnan(one_dimensional_cells_mean)] = 0
-        zero_dimensional_cells_mean = torch.nanmean(x_0, dim=0)
-        zero_dimensional_cells_mean[torch.isnan(zero_dimensional_cells_mean)] = 0
-
-        x_2f = torch.flatten(two_dimensional_cells_mean)
-        x_1f = torch.flatten(one_dimensional_cells_mean)
-        x_0f = torch.flatten(zero_dimensional_cells_mean)
-
-        return x_0f + x_1f + x_2f
+        return x

--- a/topomodelx/nn/simplicial/scconv_layer.py
+++ b/topomodelx/nn/simplicial/scconv_layer.py
@@ -161,16 +161,16 @@ class SCConvLayer(torch.nn.Module):
         """
         x0_level_0_0 = self.conv_0_to_0(x_0, adjacency_up_0_norm)
 
-        x0_level_1_0 = self.conv_1_to_0(x_1, incidence_1)
+        x0_level_1_0 = self.conv_1_to_0(x_1, incidence_1.T)
 
-        x0_level_0_1 = self.conv_0_to_1(x_0, incidence_1_norm)
+        x0_level_0_1 = self.conv_0_to_1(x_0, incidence_1_norm.T)
 
         adj_norm = adjacency_down_1_norm.add(adjacency_up_1_norm)
         x1_level_1_1 = self.conv_1_to_1(x_1, adj_norm)
 
-        x2_level_2_1 = self.conv_2_to_1(x_2, incidence_2)
+        x2_level_2_1 = self.conv_2_to_1(x_2, incidence_2.T)
 
-        x1_level_1_2 = self.conv_1_to_2(x_1, incidence_2_norm)
+        x1_level_1_2 = self.conv_1_to_2(x_1, incidence_2_norm.T)
 
         x_2_level_2_2 = self.conv_2_to_2(x_2, adjacency_down_2_norm)
 

--- a/tutorials/simplicial/san_train.ipynb
+++ b/tutorials/simplicial/san_train.ipynb
@@ -273,7 +273,7 @@
     "x_2 = []\n",
     "for k, v in dataset.get_simplex_attributes(\"face_feat\").items():\n",
     "    x_2.append(v)\n",
-    "x_2 = np.stack(x_2)\n",
+    "x_2 = torch.tensor(np.stack(x_2))\n",
     "print(f\"There are {x_2.shape[0]} faces with features of dimension {x_2.shape[1]}.\")"
    ]
   },

--- a/tutorials/simplicial/san_train.ipynb
+++ b/tutorials/simplicial/san_train.ipynb
@@ -775,7 +775,6 @@
     "            y_pred_test = torch.where(\n",
     "                y_hat_test > 0.5, torch.tensor(1), torch.tensor(0)\n",
     "            )\n",
-    "            # _pred_test = torch.softmax(y_hat_test,dim=1).ge(0.5).float()\n",
     "            test_accuracy = (\n",
     "                torch.eq(y_pred_test[-len(y_test) :], y_test)\n",
     "                .all(dim=1)\n",

--- a/tutorials/simplicial/sca_cmps_train.ipynb
+++ b/tutorials/simplicial/sca_cmps_train.ipynb
@@ -24,18 +24,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
-    "import torch\n",
     "import numpy as np\n",
-    "\n",
-    "import toponetx.datasets as datasets\n",
-    "from sklearn.model_selection import train_test_split\n",
+    "import torch\n",
+    "from torch.nn.parameter import Parameter\n",
+    "import toponetx.datasets.graph as graph\n",
+    "from torch_geometric.utils.convert import to_networkx\n",
     "\n",
     "from topomodelx.nn.simplicial.sca_cmps import SCACMPS\n",
-    "from topomodelx.utils.sparse import from_sparse"
+    "from topomodelx.utils.sparse import from_sparse\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
    ]
   },
   {
@@ -47,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -69,75 +81,56 @@
    "source": [
     "# Pre-processing\n",
     "\n",
-    "## Import data ##\n",
+    "## Import dataset ##\n",
     "\n",
-    "The first step is to import the dataset, shrec16, a benchmark dataset for 3D mesh classification. We then lift each graph into our domain of choice, a simplicial complex.\n",
+    "The first step is to import the Karate Club (https://www.jstor.org/stable/3629752) dataset. This is a singular graph with 34 nodes that belong to two different social groups. We will use these groups for the task of node-level binary classification.\n",
     "\n",
-    "We also retrieve:\n",
-    "- input signals `x_0`, `x_1`, and `x_2` on the nodes (0-cells), edges (1-cells), and faces (2-cells) for each complex: these will be the model's inputs,\n",
-    "- a scalar classification label `y` associated to the simplicial complex."
+    "We must first lift our graph dataset into the simplicial complex domain."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loading shrec 16 small dataset...\n",
-      "\n",
-      "done!\n"
+      "Simplicial Complex with shape (34, 78, 45, 11, 2) and dimension 4\n"
      ]
     }
    ],
    "source": [
-    "shrec, _ = datasets.mesh.shrec_16(size=\"small\")\n",
-    "\n",
-    "shrec = {key: np.array(value) for key, value in shrec.items()}\n",
-    "x_0s = shrec[\"node_feat\"]\n",
-    "x_1s = shrec[\"edge_feat\"]\n",
-    "x_2s = shrec[\"face_feat\"]\n",
-    "\n",
-    "ys = shrec[\"label\"]\n",
-    "scs = shrec[\"complexes\"]"
+    "dataset = graph.karate_club(complex_type=\"simplicial\")\n",
+    "print(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The 6th simplicial complex has 252 nodes with features of dimension 6.\n",
-      "The 6th simplicial complex has 750 edges with features of dimension 10.\n",
-      "The 6th simplicial complex has 500 faces with features of dimension 7.\n"
-     ]
+     "data": {
+      "text/plain": [
+       "(34, 78, 45, 11, 2)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "i_complex = 6\n",
-    "print(\n",
-    "    f\"The {i_complex}th simplicial complex has {x_0s[i_complex].shape[0]} nodes with features of dimension {x_0s[i_complex].shape[1]}.\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"The {i_complex}th simplicial complex has {x_1s[i_complex].shape[0]} edges with features of dimension {x_1s[i_complex].shape[1]}.\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"The {i_complex}th simplicial complex has {x_2s[i_complex].shape[0]} faces with features of dimension {x_2s[i_complex].shape[1]}.\"\n",
-    ")"
+    "dataset.shape"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Preparing the inputs to test each message passing scheme:\n",
+    "## Define neighborhood structures. ##\n",
     "\n",
     "#### Coadjacency Message Passing Scheme (CMPS):\n",
     "This will require features from faces, and edges again, but outputs features on the edges. The first neighborhood matrix will be the level 2 lower Laplacian, $L_{\\downarrow, 2}$, and the second neighborhood matrix will be the transpose of the incidence matrix of the faces, $B_{2}^T$."
@@ -145,30 +138,148 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
-    "laplacian_down_1_list = []\n",
-    "laplacian_down_2_list = []\n",
-    "incidence1_t_list = []\n",
-    "incidence2_t_list = []\n",
+    "laplacian_down_1 = dataset.down_laplacian_matrix(rank=1)\n",
+    "laplacian_down_2 = dataset.down_laplacian_matrix(rank=2)\n",
+    "incidence_1_t = dataset.incidence_matrix(rank=1).T\n",
+    "incidence_2_t = dataset.incidence_matrix(rank=2).T\n",
     "\n",
-    "for sc in scs:\n",
-    "    laplacian_down_1 = sc.down_laplacian_matrix(rank=1)\n",
-    "    laplacian_down_2 = sc.down_laplacian_matrix(rank=2)\n",
-    "    incidence_1_t = sc.incidence_matrix(rank=1).T\n",
-    "    incidence_2_t = sc.incidence_matrix(rank=2).T\n",
+    "laplacian_down_1 = from_sparse(laplacian_down_1)\n",
+    "laplacian_down_2 = from_sparse(laplacian_down_2)\n",
+    "incidence_1_t = from_sparse(incidence_1_t)\n",
+    "incidence_2_t = from_sparse(incidence_2_t)\n",
     "\n",
-    "    laplacian_down_1 = from_sparse(laplacian_down_1)\n",
-    "    laplacian_down_2 = from_sparse(laplacian_down_2)\n",
-    "    incidence_1_t = from_sparse(incidence_1_t)\n",
-    "    incidence_2_t = from_sparse(incidence_2_t)\n",
+    "laplacian_down_list = [laplacian_down_1, laplacian_down_2]\n",
+    "incidence_t_list = [incidence_1_t, incidence_2_t]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import signal ##\n",
     "\n",
-    "    laplacian_down_1_list.append(laplacian_down_1)\n",
-    "    laplacian_down_2_list.append(laplacian_down_2)\n",
-    "    incidence1_t_list.append(incidence_1_t)\n",
-    "    incidence2_t_list.append(incidence_2_t)"
+    "We retrieve an input signal on the nodes, edges and faces. The signal will have shape $n_\\text{simplicial} \\times$ in_channels, where in_channels is the dimension of each simplicial's feature. Here, we have in_channels = channels_nodes $ = 2$. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 34 nodes with features of dimension 2.\n",
+      "There are 78 edges with features of dimension 2.\n",
+      "There are 45 faces with features of dimension 2.\n"
+     ]
+    }
+   ],
+   "source": [
+    "x_0 = []\n",
+    "for _, v in dataset.get_simplex_attributes(\"node_feat\").items():\n",
+    "    x_0.append(v)\n",
+    "x_0 = torch.tensor(np.stack(x_0))\n",
+    "channels_nodes = x_0.shape[-1]\n",
+    "print(f\"There are {x_0.shape[0]} nodes with features of dimension {x_0.shape[1]}.\")\n",
+    "\n",
+    "x_1 = []\n",
+    "for k, v in dataset.get_simplex_attributes(\"edge_feat\").items():\n",
+    "    x_1.append(v)\n",
+    "x_1 = torch.tensor(np.stack(x_1))\n",
+    "print(f\"There are {x_1.shape[0]} edges with features of dimension {x_1.shape[1]}.\")\n",
+    "\n",
+    "x_2 = []\n",
+    "for k, v in dataset.get_simplex_attributes(\"face_feat\").items():\n",
+    "    x_2.append(v)\n",
+    "x_2 = torch.tensor(np.stack(x_2))\n",
+    "print(f\"There are {x_2.shape[0]} faces with features of dimension {x_2.shape[1]}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also pre-define the number output channels of the model, in this case the number of node classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "in_channels = x_0.shape[-1]\n",
+    "out_channels = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define binary labels\n",
+    "We retrieve the labels associated to the nodes of each input simplex. In the KarateClub dataset, two social groups emerge. So we assign binary labels to the nodes indicating of which group they are a part.\n",
+    "\n",
+    "We convert one-hot encode the binary labels, and keep the first four nodes for the purpose of testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = np.array(\n",
+    "    [\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        0,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        0,\n",
+    "        0,\n",
+    "        1,\n",
+    "        1,\n",
+    "        0,\n",
+    "        1,\n",
+    "        0,\n",
+    "        1,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "    ]\n",
+    ")\n",
+    "y_true = np.zeros((34, 2))\n",
+    "y_true[:, 0] = y\n",
+    "y_true[:, 1] = 1 - y\n",
+    "y_train = y_true[:30]\n",
+    "y_test = y_true[-4:]\n",
+    "\n",
+    "y_train = torch.from_numpy(y_train)\n",
+    "y_test = torch.from_numpy(y_test)"
    ]
   },
   {
@@ -182,105 +293,335 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
-    "channels_list = [x_0s[0].shape[-1], x_1s[0].shape[-1], x_2s[0].shape[-1]]\n",
+    "class Network(torch.nn.Module):\n",
+    "    def __init__(self, in_channels_all, out_channels, complex_dim, n_layers=1):\n",
+    "        super(Network, self).__init__()\n",
+    "        self.base_model = SCACMPS(\n",
+    "            in_channels_all=in_channels_all,\n",
+    "            complex_dim=complex_dim,\n",
+    "            n_layers=n_layers,\n",
+    "        )\n",
+    "        self.lin0 = torch.nn.Linear(in_channels_all[0], out_channels)\n",
     "\n",
-    "complex_dim = 3"
+    "    def forward(self, x, laplacian_down_list, incidence_t_list):\n",
+    "        x = self.base_model(x, laplacian_down_list, incidence_t_list)\n",
+    "        x_0 = self.lin0(x[0])\n",
+    "        return torch.softmax(x_0, dim=1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(100,)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "x_0s.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Train and Test Split"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(80,)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test_size = 0.2\n",
-    "x_0_train, x_0_test = train_test_split(x_0s, test_size=test_size, shuffle=False)\n",
-    "x_1_train, x_1_test = train_test_split(x_1s, test_size=test_size, shuffle=False)\n",
-    "x_2_train, x_2_test = train_test_split(x_2s, test_size=test_size, shuffle=False)\n",
-    "\n",
-    "laplacian_down_1_train, laplacian_down_1_test = train_test_split(\n",
-    "    laplacian_down_1_list, test_size=test_size, shuffle=False\n",
-    ")\n",
-    "laplacian_down_2_train, laplacian_down_2_test = train_test_split(\n",
-    "    laplacian_down_2_list, test_size=test_size, shuffle=False\n",
-    ")\n",
-    "incidence1_t_train, incidence1_t_test = train_test_split(\n",
-    "    incidence1_t_list, test_size=test_size, shuffle=False\n",
-    ")\n",
-    "incidence2_t_train, incidence2_t_test = train_test_split(\n",
-    "    incidence2_t_list, test_size=test_size, shuffle=False\n",
-    ")\n",
-    "\n",
-    "y_train, y_test = train_test_split(ys, test_size=test_size, shuffle=False)\n",
-    "y_train.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Training and Testing Model\n",
-    "Because the SCA implementation in [HZPMC22]_ was used for clustering, we did the same in one dimension to train on the int classification labels provided my the shrec16 dataset. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = SCACMPS(\n",
-    "    channels_list=channels_list,\n",
+    "x = [x_0, x_1, x_2]\n",
+    "in_channels_all = [x_0[0].shape[-1], x_1[0].shape[-1], x_2[0].shape[-1]]\n",
+    "out_channels = 2\n",
+    "complex_dim = 3\n",
+    "n_layers = 1\n",
+    "\n",
+    "model = Network(\n",
+    "    in_channels_all=in_channels_all,\n",
+    "    out_channels=out_channels,\n",
     "    complex_dim=complex_dim,\n",
-    "    n_classes=1,\n",
-    "    n_layers=3,\n",
-    "    att=False,\n",
+    "    n_layers=n_layers,\n",
     ")\n",
-    "model = model.to(device)\n",
-    "opt = torch.optim.Adam(model.parameters(), lr=0.1)\n",
-    "loss_fn = torch.nn.MSELoss()"
+    "optimizer = torch.optim.Adam(model.parameters(), lr=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train the Neural Network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cell performs the training, looping over the network for a low number of epochs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch: 1 loss: 0.7272 Train_acc: 0.4333\n",
+      "Epoch: 2 loss: 0.7215 Train_acc: 0.5667\n",
+      "Epoch: 3 loss: 0.7166 Train_acc: 0.5667\n",
+      "Epoch: 4 loss: 0.7126 Train_acc: 0.5667\n",
+      "Epoch: 5 loss: 0.7097 Train_acc: 0.5667\n",
+      "Epoch: 6 loss: 0.7076 Train_acc: 0.5667\n",
+      "Epoch: 7 loss: 0.7062 Train_acc: 0.5667\n",
+      "Epoch: 8 loss: 0.7052 Train_acc: 0.5667\n",
+      "Epoch: 9 loss: 0.7044 Train_acc: 0.5667\n",
+      "Epoch: 10 loss: 0.7037 Train_acc: 0.5667\n",
+      "Test_acc: 0.0000\n",
+      "Epoch: 11 loss: 0.7028 Train_acc: 0.5667\n",
+      "Epoch: 12 loss: 0.7018 Train_acc: 0.5667\n",
+      "Epoch: 13 loss: 0.7006 Train_acc: 0.5667\n",
+      "Epoch: 14 loss: 0.6991 Train_acc: 0.5667\n",
+      "Epoch: 15 loss: 0.6974 Train_acc: 0.5667\n",
+      "Epoch: 16 loss: 0.6955 Train_acc: 0.5667\n",
+      "Epoch: 17 loss: 0.6934 Train_acc: 0.5667\n",
+      "Epoch: 18 loss: 0.6913 Train_acc: 0.5667\n",
+      "Epoch: 19 loss: 0.6891 Train_acc: 0.5667\n",
+      "Epoch: 20 loss: 0.6870 Train_acc: 0.5667\n",
+      "Test_acc: 0.0000\n",
+      "Epoch: 21 loss: 0.6852 Train_acc: 0.5667\n",
+      "Epoch: 22 loss: 0.6836 Train_acc: 0.5667\n",
+      "Epoch: 23 loss: 0.6822 Train_acc: 0.7000\n",
+      "Epoch: 24 loss: 0.6810 Train_acc: 0.9333\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch: 25 loss: 0.6798 Train_acc: 0.9667\n",
+      "Epoch: 26 loss: 0.6784 Train_acc: 1.0000\n",
+      "Epoch: 27 loss: 0.6768 Train_acc: 1.0000\n",
+      "Epoch: 28 loss: 0.6750 Train_acc: 1.0000\n",
+      "Epoch: 29 loss: 0.6731 Train_acc: 0.9667\n",
+      "Epoch: 30 loss: 0.6712 Train_acc: 0.9333\n",
+      "Test_acc: 0.5000\n",
+      "Epoch: 31 loss: 0.6695 Train_acc: 0.9333\n",
+      "Epoch: 32 loss: 0.6679 Train_acc: 0.9333\n",
+      "Epoch: 33 loss: 0.6664 Train_acc: 0.9000\n",
+      "Epoch: 34 loss: 0.6651 Train_acc: 0.9000\n",
+      "Epoch: 35 loss: 0.6637 Train_acc: 0.9000\n",
+      "Epoch: 36 loss: 0.6623 Train_acc: 0.9000\n",
+      "Epoch: 37 loss: 0.6608 Train_acc: 0.9000\n",
+      "Epoch: 38 loss: 0.6593 Train_acc: 0.9333\n",
+      "Epoch: 39 loss: 0.6577 Train_acc: 0.9333\n",
+      "Epoch: 40 loss: 0.6562 Train_acc: 0.9333\n",
+      "Test_acc: 0.7500\n",
+      "Epoch: 41 loss: 0.6547 Train_acc: 0.9667\n",
+      "Epoch: 42 loss: 0.6533 Train_acc: 1.0000\n",
+      "Epoch: 43 loss: 0.6520 Train_acc: 1.0000\n",
+      "Epoch: 44 loss: 0.6507 Train_acc: 1.0000\n",
+      "Epoch: 45 loss: 0.6494 Train_acc: 0.9667\n",
+      "Epoch: 46 loss: 0.6481 Train_acc: 0.9667\n",
+      "Epoch: 47 loss: 0.6468 Train_acc: 0.9667\n",
+      "Epoch: 48 loss: 0.6455 Train_acc: 1.0000\n",
+      "Epoch: 49 loss: 0.6441 Train_acc: 1.0000\n",
+      "Epoch: 50 loss: 0.6429 Train_acc: 1.0000\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 51 loss: 0.6417 Train_acc: 1.0000\n",
+      "Epoch: 52 loss: 0.6405 Train_acc: 1.0000\n",
+      "Epoch: 53 loss: 0.6393 Train_acc: 1.0000\n",
+      "Epoch: 54 loss: 0.6382 Train_acc: 1.0000\n",
+      "Epoch: 55 loss: 0.6370 Train_acc: 1.0000\n",
+      "Epoch: 56 loss: 0.6358 Train_acc: 1.0000\n",
+      "Epoch: 57 loss: 0.6347 Train_acc: 1.0000\n",
+      "Epoch: 58 loss: 0.6336 Train_acc: 1.0000\n",
+      "Epoch: 59 loss: 0.6325 Train_acc: 0.9667\n",
+      "Epoch: 60 loss: 0.6314 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 61 loss: 0.6304 Train_acc: 0.9667\n",
+      "Epoch: 62 loss: 0.6294 Train_acc: 0.9667\n",
+      "Epoch: 63 loss: 0.6283 Train_acc: 0.9667\n",
+      "Epoch: 64 loss: 0.6273 Train_acc: 0.9667\n",
+      "Epoch: 65 loss: 0.6263 Train_acc: 0.9667\n",
+      "Epoch: 66 loss: 0.6253 Train_acc: 0.9667\n",
+      "Epoch: 67 loss: 0.6244 Train_acc: 0.9667\n",
+      "Epoch: 68 loss: 0.6234 Train_acc: 0.9667\n",
+      "Epoch: 69 loss: 0.6225 Train_acc: 0.9667\n",
+      "Epoch: 70 loss: 0.6216 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 71 loss: 0.6207 Train_acc: 0.9667\n",
+      "Epoch: 72 loss: 0.6198 Train_acc: 0.9667\n",
+      "Epoch: 73 loss: 0.6189 Train_acc: 0.9667\n",
+      "Epoch: 74 loss: 0.6180 Train_acc: 0.9667\n",
+      "Epoch: 75 loss: 0.6172 Train_acc: 0.9667\n",
+      "Epoch: 76 loss: 0.6164 Train_acc: 0.9667\n",
+      "Epoch: 77 loss: 0.6155 Train_acc: 0.9667\n",
+      "Epoch: 78 loss: 0.6147 Train_acc: 0.9667\n",
+      "Epoch: 79 loss: 0.6139 Train_acc: 0.9667\n",
+      "Epoch: 80 loss: 0.6131 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 81 loss: 0.6124 Train_acc: 0.9667\n",
+      "Epoch: 82 loss: 0.6116 Train_acc: 0.9667\n",
+      "Epoch: 83 loss: 0.6108 Train_acc: 0.9667\n",
+      "Epoch: 84 loss: 0.6101 Train_acc: 0.9667\n",
+      "Epoch: 85 loss: 0.6094 Train_acc: 0.9667\n",
+      "Epoch: 86 loss: 0.6086 Train_acc: 0.9667\n",
+      "Epoch: 87 loss: 0.6079 Train_acc: 0.9667\n",
+      "Epoch: 88 loss: 0.6072 Train_acc: 0.9667\n",
+      "Epoch: 89 loss: 0.6065 Train_acc: 0.9667\n",
+      "Epoch: 90 loss: 0.6058 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 91 loss: 0.6052 Train_acc: 0.9667\n",
+      "Epoch: 92 loss: 0.6045 Train_acc: 0.9667\n",
+      "Epoch: 93 loss: 0.6038 Train_acc: 0.9667\n",
+      "Epoch: 94 loss: 0.6032 Train_acc: 0.9667\n",
+      "Epoch: 95 loss: 0.6026 Train_acc: 0.9667\n",
+      "Epoch: 96 loss: 0.6019 Train_acc: 0.9667\n",
+      "Epoch: 97 loss: 0.6013 Train_acc: 0.9667\n",
+      "Epoch: 98 loss: 0.6007 Train_acc: 0.9667\n",
+      "Epoch: 99 loss: 0.6001 Train_acc: 0.9667\n",
+      "Epoch: 100 loss: 0.5995 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 101 loss: 0.5989 Train_acc: 0.9667\n",
+      "Epoch: 102 loss: 0.5983 Train_acc: 0.9667\n",
+      "Epoch: 103 loss: 0.5977 Train_acc: 0.9667\n",
+      "Epoch: 104 loss: 0.5972 Train_acc: 0.9667\n",
+      "Epoch: 105 loss: 0.5966 Train_acc: 0.9667\n",
+      "Epoch: 106 loss: 0.5961 Train_acc: 0.9667\n",
+      "Epoch: 107 loss: 0.5955 Train_acc: 0.9667\n",
+      "Epoch: 108 loss: 0.5950 Train_acc: 0.9667\n",
+      "Epoch: 109 loss: 0.5944 Train_acc: 0.9667\n",
+      "Epoch: 110 loss: 0.5939 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 111 loss: 0.5934 Train_acc: 0.9667\n",
+      "Epoch: 112 loss: 0.5929 Train_acc: 0.9667\n",
+      "Epoch: 113 loss: 0.5924 Train_acc: 0.9667\n",
+      "Epoch: 114 loss: 0.5919 Train_acc: 0.9667\n",
+      "Epoch: 115 loss: 0.5914 Train_acc: 0.9667\n",
+      "Epoch: 116 loss: 0.5909 Train_acc: 0.9667\n",
+      "Epoch: 117 loss: 0.5904 Train_acc: 0.9667\n",
+      "Epoch: 118 loss: 0.5899 Train_acc: 0.9667\n",
+      "Epoch: 119 loss: 0.5894 Train_acc: 0.9667\n",
+      "Epoch: 120 loss: 0.5890 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 121 loss: 0.5885 Train_acc: 0.9667\n",
+      "Epoch: 122 loss: 0.5881 Train_acc: 0.9667\n",
+      "Epoch: 123 loss: 0.5876 Train_acc: 0.9667\n",
+      "Epoch: 124 loss: 0.5872 Train_acc: 0.9667\n",
+      "Epoch: 125 loss: 0.5867 Train_acc: 0.9667\n",
+      "Epoch: 126 loss: 0.5863 Train_acc: 0.9667\n",
+      "Epoch: 127 loss: 0.5859 Train_acc: 0.9667\n",
+      "Epoch: 128 loss: 0.5854 Train_acc: 0.9667\n",
+      "Epoch: 129 loss: 0.5850 Train_acc: 0.9667\n",
+      "Epoch: 130 loss: 0.5846 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 131 loss: 0.5842 Train_acc: 0.9667\n",
+      "Epoch: 132 loss: 0.5838 Train_acc: 0.9667\n",
+      "Epoch: 133 loss: 0.5834 Train_acc: 0.9667\n",
+      "Epoch: 134 loss: 0.5830 Train_acc: 0.9667\n",
+      "Epoch: 135 loss: 0.5826 Train_acc: 0.9667\n",
+      "Epoch: 136 loss: 0.5822 Train_acc: 0.9667\n",
+      "Epoch: 137 loss: 0.5818 Train_acc: 0.9667\n",
+      "Epoch: 138 loss: 0.5814 Train_acc: 0.9667\n",
+      "Epoch: 139 loss: 0.5810 Train_acc: 0.9667\n",
+      "Epoch: 140 loss: 0.5806 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 141 loss: 0.5803 Train_acc: 0.9667\n",
+      "Epoch: 142 loss: 0.5799 Train_acc: 0.9667\n",
+      "Epoch: 143 loss: 0.5795 Train_acc: 0.9667\n",
+      "Epoch: 144 loss: 0.5792 Train_acc: 0.9667\n",
+      "Epoch: 145 loss: 0.5788 Train_acc: 0.9667\n",
+      "Epoch: 146 loss: 0.5785 Train_acc: 0.9667\n",
+      "Epoch: 147 loss: 0.5781 Train_acc: 0.9667\n",
+      "Epoch: 148 loss: 0.5778 Train_acc: 0.9667\n",
+      "Epoch: 149 loss: 0.5774 Train_acc: 0.9667\n",
+      "Epoch: 150 loss: 0.5771 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 151 loss: 0.5768 Train_acc: 0.9667\n",
+      "Epoch: 152 loss: 0.5764 Train_acc: 0.9667\n",
+      "Epoch: 153 loss: 0.5761 Train_acc: 0.9667\n",
+      "Epoch: 154 loss: 0.5758 Train_acc: 0.9667\n",
+      "Epoch: 155 loss: 0.5755 Train_acc: 0.9667\n",
+      "Epoch: 156 loss: 0.5751 Train_acc: 0.9667\n",
+      "Epoch: 157 loss: 0.5748 Train_acc: 0.9667\n",
+      "Epoch: 158 loss: 0.5745 Train_acc: 0.9667\n",
+      "Epoch: 159 loss: 0.5742 Train_acc: 0.9667\n",
+      "Epoch: 160 loss: 0.5739 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 161 loss: 0.5736 Train_acc: 0.9667\n",
+      "Epoch: 162 loss: 0.5733 Train_acc: 0.9667\n",
+      "Epoch: 163 loss: 0.5730 Train_acc: 0.9667\n",
+      "Epoch: 164 loss: 0.5727 Train_acc: 0.9667\n",
+      "Epoch: 165 loss: 0.5724 Train_acc: 0.9667\n",
+      "Epoch: 166 loss: 0.5721 Train_acc: 0.9667\n",
+      "Epoch: 167 loss: 0.5718 Train_acc: 0.9667\n",
+      "Epoch: 168 loss: 0.5715 Train_acc: 0.9667\n",
+      "Epoch: 169 loss: 0.5712 Train_acc: 0.9667\n",
+      "Epoch: 170 loss: 0.5709 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 171 loss: 0.5707 Train_acc: 0.9667\n",
+      "Epoch: 172 loss: 0.5704 Train_acc: 0.9667\n",
+      "Epoch: 173 loss: 0.5701 Train_acc: 0.9667\n",
+      "Epoch: 174 loss: 0.5698 Train_acc: 0.9667\n",
+      "Epoch: 175 loss: 0.5696 Train_acc: 0.9667\n",
+      "Epoch: 176 loss: 0.5693 Train_acc: 0.9667\n",
+      "Epoch: 177 loss: 0.5690 Train_acc: 0.9667\n",
+      "Epoch: 178 loss: 0.5688 Train_acc: 0.9667\n",
+      "Epoch: 179 loss: 0.5685 Train_acc: 0.9667\n",
+      "Epoch: 180 loss: 0.5683 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 181 loss: 0.5680 Train_acc: 0.9667\n",
+      "Epoch: 182 loss: 0.5678 Train_acc: 0.9667\n",
+      "Epoch: 183 loss: 0.5675 Train_acc: 0.9667\n",
+      "Epoch: 184 loss: 0.5673 Train_acc: 0.9667\n",
+      "Epoch: 185 loss: 0.5670 Train_acc: 0.9667\n",
+      "Epoch: 186 loss: 0.5668 Train_acc: 0.9667\n",
+      "Epoch: 187 loss: 0.5665 Train_acc: 0.9667\n",
+      "Epoch: 188 loss: 0.5663 Train_acc: 0.9667\n",
+      "Epoch: 189 loss: 0.5660 Train_acc: 0.9667\n",
+      "Epoch: 190 loss: 0.5658 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 191 loss: 0.5656 Train_acc: 0.9667\n",
+      "Epoch: 192 loss: 0.5653 Train_acc: 0.9667\n",
+      "Epoch: 193 loss: 0.5651 Train_acc: 0.9667\n",
+      "Epoch: 194 loss: 0.5649 Train_acc: 0.9667\n",
+      "Epoch: 195 loss: 0.5647 Train_acc: 0.9667\n",
+      "Epoch: 196 loss: 0.5644 Train_acc: 0.9667\n",
+      "Epoch: 197 loss: 0.5642 Train_acc: 0.9667\n",
+      "Epoch: 198 loss: 0.5640 Train_acc: 0.9667\n",
+      "Epoch: 199 loss: 0.5638 Train_acc: 0.9667\n",
+      "Epoch: 200 loss: 0.5635 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_interval = 10\n",
+    "num_epochs = 200\n",
+    "for epoch_i in range(1, num_epochs + 1):\n",
+    "    epoch_loss = []\n",
+    "    model.train()\n",
+    "    optimizer.zero_grad()\n",
+    "\n",
+    "    y_hat = model(x, laplacian_down_list, incidence_t_list)\n",
+    "    loss = torch.nn.functional.binary_cross_entropy_with_logits(\n",
+    "        y_hat[: len(y_train)].float(), y_train.float()\n",
+    "    )\n",
+    "    epoch_loss.append(loss.item())\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    y_pred = torch.where(y_hat > 0.5, torch.tensor(1), torch.tensor(0))\n",
+    "    accuracy = (y_pred[: len(y_train)] == y_train).all(dim=1).float().mean().item()\n",
+    "    print(\n",
+    "        f\"Epoch: {epoch_i} loss: {np.mean(epoch_loss):.4f} Train_acc: {accuracy:.4f}\",\n",
+    "        flush=True,\n",
+    "    )\n",
+    "    if epoch_i % test_interval == 0:\n",
+    "        with torch.no_grad():\n",
+    "            y_hat_test = model(x, laplacian_down_list, incidence_t_list)\n",
+    "            y_pred_test = torch.where(\n",
+    "                y_hat_test > 0.5, torch.tensor(1), torch.tensor(0)\n",
+    "            )\n",
+    "            test_accuracy = (\n",
+    "                torch.eq(y_pred_test[-len(y_test) :], y_test)\n",
+    "                .all(dim=1)\n",
+    "                .float()\n",
+    "                .mean()\n",
+    "                .item()\n",
+    "            )\n",
+    "            print(f\"Test_acc: {test_accuracy:.4f}\", flush=True)"
    ]
   },
   {

--- a/tutorials/simplicial/sccnn_train.ipynb
+++ b/tutorials/simplicial/sccnn_train.ipynb
@@ -605,7 +605,7 @@
    "source": [
     "## Import signal ##\n",
     "\n",
-    "Since our task will be node classification, we must retrieve an input signal on the nodes. The signal will have shape $n_\\text{nodes} \\times$ in_channels, where in_channels is the dimension of each cell's feature. Here, we have in_channels = channels_nodes $ = 2$. "
+    "We retrieve an input signal on the nodes, edges and faces. The signal will have shape $n_\\text{simplicial} \\times$ in_channels, where in_channels is the dimension of each simplicial's feature. Here, we have in_channels = channels_nodes $ = 2$. "
    ]
   },
   {
@@ -951,9 +951,6 @@
     "    model.train()\n",
     "    optimizer.zero_grad()\n",
     "    y_hat = model(x_all, laplacian_all, incidence_all)\n",
-    "    # We project the edge-level output of the model to the node-level\n",
-    "    # and apply softmax fn to get the final node-level classification output\n",
-    "    # y_hat = torch.softmax(torch.sparse.mm(incidence_1, y_hat_edge), dim=1)\n",
     "    y_hat = torch.softmax(y_hat, dim=1)\n",
     "    loss = torch.nn.functional.binary_cross_entropy(\n",
     "        y_hat[: len(y_train)].float(), y_train.float()\n",

--- a/tutorials/simplicial/scconv_train.ipynb
+++ b/tutorials/simplicial/scconv_train.ipynb
@@ -230,65 +230,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor(indices=tensor([[ 0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,\n",
-       "                         7,  7,  8,  8,  9,  9, 10, 10, 11, 11, 12, 12, 13, 13,\n",
-       "                        14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20,\n",
-       "                        21, 21, 22, 22, 23, 23, 24, 24, 25, 25, 26, 26, 27, 27,\n",
-       "                        28, 28, 29, 29, 30, 30, 31, 31, 32, 32, 33, 33, 34, 34,\n",
-       "                        35, 35, 36, 36, 37, 37, 38, 38, 39, 39, 40, 40, 41, 41,\n",
-       "                        42, 42, 43, 43, 44, 44, 45, 45, 46, 46, 47, 47, 48, 48,\n",
-       "                        49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55,\n",
-       "                        56, 56, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 62, 62,\n",
-       "                        63, 63, 64, 64, 65, 65, 66, 66, 67, 67, 68, 68, 69, 69,\n",
-       "                        70, 70, 71, 71, 72, 72, 73, 73, 74, 74, 75, 75, 76, 76,\n",
-       "                        77, 77],\n",
-       "                       [ 0,  1,  0,  2,  0,  3,  0,  4,  0,  5,  0,  6,  0,  7,\n",
-       "                         0,  8,  0, 10,  0, 11,  0, 12,  0, 13,  0, 17,  0, 19,\n",
-       "                         0, 21,  0, 31,  1,  2,  1,  3,  1,  7,  1, 13,  1, 17,\n",
-       "                         1, 19,  1, 21,  1, 30,  2,  3,  2,  7,  2,  8,  2,  9,\n",
-       "                         2, 13,  2, 27,  2, 28,  2, 32,  3,  7,  3, 12,  3, 13,\n",
-       "                         4,  6,  4, 10,  5,  6,  5, 10,  5, 16,  6, 16,  8, 30,\n",
-       "                         8, 32,  8, 33,  9, 33, 13, 33, 14, 32, 14, 33, 15, 32,\n",
-       "                        15, 33, 18, 32, 18, 33, 19, 33, 20, 32, 20, 33, 22, 32,\n",
-       "                        22, 33, 23, 25, 23, 27, 23, 29, 23, 32, 23, 33, 24, 25,\n",
-       "                        24, 27, 24, 31, 25, 31, 26, 29, 26, 33, 27, 33, 28, 31,\n",
-       "                        28, 33, 29, 32, 29, 33, 30, 32, 30, 33, 31, 32, 31, 33,\n",
-       "                        32, 33]]),\n",
-       "       values=tensor([-1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
-       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
-       "                      -1.,  1.]),\n",
-       "       size=(78, 34), nnz=156, layout=torch.sparse_coo)"
-      ]
-     },
-     "execution_count": 79,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "incidence_1"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "KHCGA1gY0pEj"
@@ -296,9 +237,7 @@
    "source": [
     "## Import signal ##\n",
     "\n",
-    "We define edge features to be the gradient of the nodes features, i.e. given the node feature matrix $X_0$, we compute the edge features matrix as $X_1 = B_1^TX_0$. We will finally obtain the estimated node labels from the updated edge features by multiplying them again with $B_1$, i.e. the final nodes features are computed as the divergence of the final edge features.\n",
-    "\n",
-    "**Remark.** Please notice that also this way of deriving edges/nodes features from nodes/edges features could be seen as a (non-learnable) message passing between rank-0/1 cells (nodes/edges) and rank-1/0 cells (nodes)."
+    "We retrieve an input signal on the nodes, edges and faces. The signal will have shape $n_\\text{simplicial} \\times$ in_channels, where in_channels is the dimension of each simplicial's feature. Here, we have in_channels = channels_nodes $ = 2$. "
    ]
   },
   {
@@ -346,7 +285,7 @@
     "id": "PWQ_NRiU0pEl"
    },
    "source": [
-    "Hence, the final input features are defined by this sum, and we also pre-define the number of hidden and output channels of the model."
+    "We also pre-define the number output channels of the model, in this case the number of node classes."
    ]
   },
   {
@@ -785,9 +724,6 @@
     "        adjacency_down_1_norm,\n",
     "        adjacency_down_2_norm,\n",
     "    )\n",
-    "    # We project the edge-level output of the model to the node-level\n",
-    "    # and apply softmax fn to get the final node-level classification output\n",
-    "    # y_hat = torch.softmax(torch.sparse.mm(incidence_0_1, y_hat_edge), dim=1)\n",
     "    loss = torch.nn.functional.binary_cross_entropy_with_logits(\n",
     "        y_hat[: len(y_train)].float(), y_train.float()\n",
     "    )\n",
@@ -819,7 +755,6 @@
     "            y_pred_test = torch.where(\n",
     "                y_hat_test > 0.5, torch.tensor(1), torch.tensor(0)\n",
     "            )\n",
-    "            # _pred_test = torch.softmax(y_hat_test,dim=1).ge(0.5).float()\n",
     "            test_accuracy = (\n",
     "                torch.eq(y_pred_test[-len(y_test) :], y_test)\n",
     "                .all(dim=1)\n",

--- a/tutorials/simplicial/scconv_train.ipynb
+++ b/tutorials/simplicial/scconv_train.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "🟥 $\\quad m^{(1 \\rightarrow 2)}_{y \\rightarrow x}  = (\\tilde B_2)_{xy} \\cdot h_y^{t,(1)} \\cdot \\Theta^{t,(1 \\rightarrow 2)}$\n",
     "\n",
-    "🟥 $\\quad m^{(2 \\rightarrow 2)}_{y \\rightarrow x}  = ({\\tilde{A}_{\\downarrow,2}})\\_{xy} \\cdot h_y^{t,(2)} \\cdot \\Theta^{t,(2 \\rightarrow 2)}$\n",
+    "🟥 $\\quad m^{(2 \\rightarrow 2)}_{y \\rightarrow x}  = ({\\tilde{A}_{\\downarrow,2}})_{xy} \\cdot h_y^{t,(2)} \\cdot \\Theta^{t,(2 \\rightarrow 2)}$\n",
     "\n",
     "🟧 $\\quad m_x^{(0 \\rightarrow 0)}  = \\sum_{y \\in \\mathcal{L}_\\uparrow(x)} m_{y \\rightarrow x}^{(0 \\rightarrow 0)}$\n",
     "\n",
@@ -58,19 +58,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 52,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-13T23:56:40.324878004Z",
-     "start_time": "2023-07-13T23:56:40.279753898Z"
-    }
+    "id": "ZNrtWfL10pEe"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
-    "import torch\n",
     "import numpy as np\n",
-    "\n",
-    "import toponetx.datasets as datasets\n",
+    "import torch\n",
+    "from torch.nn.parameter import Parameter\n",
+    "import toponetx.datasets.graph as graph\n",
+    "from torch_geometric.utils.convert import to_networkx\n",
     "\n",
     "from scipy.sparse import coo_matrix\n",
     "from scipy.sparse import diags\n",
@@ -78,18 +85,18 @@
     "from topomodelx.base.aggregation import Aggregation\n",
     "\n",
     "from topomodelx.nn.simplicial.scconv import SCConv\n",
-    "from topomodelx.utils.sparse import from_sparse"
+    "from topomodelx.utils.sparse import from_sparse\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 53,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-13T23:24:30.399752783Z",
-     "start_time": "2023-07-13T23:24:30.357813405Z"
-    },
-    "collapsed": false
+    "id": "Z05cyYcw0pEh",
+    "outputId": "0ba2482b-dc68-451b-95bd-d2ea97e04378"
    },
    "outputs": [
     {
@@ -107,121 +114,87 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "GPJIacee0pEh"
+   },
    "source": [
     "# Pre-processing\n",
     "\n",
     "## Import dataset ##\n",
     "\n",
-    "The first step is to import the dataset, shrec 16, a benchmark dataset for 3D mesh classification."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-06-26T04:25:01.902814606Z",
-     "start_time": "2023-06-26T04:25:00.067431655Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading shrec 16 small dataset...\n",
-      "\n",
-      "done!\n"
-     ]
-    }
-   ],
-   "source": [
-    "shrec, _ = datasets.mesh.shrec_16(size=\"small\")\n",
+    "The first step is to import the Karate Club (https://www.jstor.org/stable/3629752) dataset. This is a singular graph with 34 nodes that belong to two different social groups. We will use these groups for the task of node-level binary classification.\n",
     "\n",
-    "shrec = {key: np.array(value) for key, value in shrec.items()}\n",
-    "x_0s = shrec[\"node_feat\"]\n",
-    "x_1s = shrec[\"edge_feat\"]\n",
-    "x_2s = shrec[\"face_feat\"]\n",
-    "\n",
-    "ys = shrec[\"label\"]\n",
-    "simplexes = shrec[\"complexes\"]"
+    "We must first lift our graph dataset into the simplicial complex domain."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 54,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-13T23:25:44.545809975Z",
-     "start_time": "2023-07-13T23:25:44.537748017Z"
-    },
-    "collapsed": false
+    "id": "BreEb4B00pEi",
+    "outputId": "fed8fb52-16b7-418e-812c-7f29bf32de1c"
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "30\n"
+      "Simplicial Complex with shape (34, 78, 45, 11, 2) and dimension 4\n"
      ]
     }
    ],
    "source": [
-    "# l = np.unique(ys, return_counts=True)\n",
-    "# print(l)\n",
-    "print(len(np.unique(ys)))"
+    "dataset = graph.karate_club(complex_type=\"simplicial\")\n",
+    "print(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 55,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-06-26T04:25:05.161535039Z",
-     "start_time": "2023-06-26T04:25:05.142961595Z"
-    },
-    "collapsed": false
+    "id": "fdT4Zjsp0pEi",
+    "outputId": "054e2a94-3503-421d-d10c-8a9ceb21cce9"
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The 0th simplicial complex has 252 nodes with features of dimension 6.\n",
-      "The 0th simplicial complex has 750 edges with features of dimension 10.\n",
-      "The 0th simplicial complex has 500 faces with features of dimension 7.\n"
-     ]
+     "data": {
+      "text/plain": [
+       "(34, 78, 45, 11, 2)"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "i_complex = 0\n",
-    "print(\n",
-    "    f\"The {i_complex}th simplicial complex has {x_0s[i_complex].shape[0]} nodes with features of dimension {x_0s[i_complex].shape[1]}.\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"The {i_complex}th simplicial complex has {x_1s[i_complex].shape[0]} edges with features of dimension {x_1s[i_complex].shape[1]}.\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"The {i_complex}th simplicial complex has {x_2s[i_complex].shape[0]} faces with features of dimension {x_2s[i_complex].shape[1]}.\"\n",
-    ")"
+    "dataset.shape"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Helper functions ##\n"
+    "# Define Neighbourhood Structures\n",
+    "\n",
+    "We create the neigborood structures expected by SSConv. The SSConv layer expects the following neighbourhood structures:\n",
+    "* incidence_1 $B_1$\n",
+    "* incidence_1_norm $\\tilde{B}_1$\n",
+    "* incidence_2 $B_2$\n",
+    "* incidence_2_norm $\\tilde{B}_1$\n",
+    "* adjacency_up_0_norm $\\tilde{A}_{\\uparrow,0}$\n",
+    "* adjacency_up_1_norm $\\tilde{A}_{\\uparrow,1}$\n",
+    "* adjacency_down_1_norm $\\tilde{A}_{\\downarrow,1}$\n",
+    "* adjacency_down_2_norm $\\tilde{A}_{\\downarrow,2}$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 56,
+   "metadata": {},
    "outputs": [],
    "source": [
+    "# Not working, it needs to be reviewed\n",
     "def normalize_higher_order_adj(A_opt):\n",
     "    \"\"\"\n",
     "    Args:\n",
@@ -242,428 +215,635 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-06-26T04:54:56.698762101Z",
-     "start_time": "2023-06-26T04:54:56.690271544Z"
-    },
-    "collapsed": false
-   },
+   "execution_count": 78,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# incidence_1_list"
+    "incidence_1_norm = incidence_0_1 = from_sparse(dataset.incidence_matrix(1))\n",
+    "incidence_1 = incidence_1_0 = from_sparse(dataset.coincidence_matrix(1))\n",
+    "incidence_2_norm = incidence_1_2 = from_sparse(dataset.incidence_matrix(2))\n",
+    "incidence_2 = incidence_2_1 = from_sparse(dataset.coincidence_matrix(2))\n",
+    "adjacency_up_0_norm = adjacency_0 = from_sparse(dataset.up_laplacian_matrix(0))\n",
+    "adjacency_up_1_norm = adjacency_1_up = from_sparse(dataset.up_laplacian_matrix(1))\n",
+    "adjacency_down_1_norm = adjacency_1_down = from_sparse(dataset.down_laplacian_matrix(1))\n",
+    "adjacency_down_2_norm = adjacency_2 = from_sparse(dataset.down_laplacian_matrix(2))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-09T09:06:50.412427908Z",
-     "start_time": "2023-07-09T09:06:50.361595391Z"
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(indices=tensor([[ 0,  0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,\n",
+       "                         7,  7,  8,  8,  9,  9, 10, 10, 11, 11, 12, 12, 13, 13,\n",
+       "                        14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20,\n",
+       "                        21, 21, 22, 22, 23, 23, 24, 24, 25, 25, 26, 26, 27, 27,\n",
+       "                        28, 28, 29, 29, 30, 30, 31, 31, 32, 32, 33, 33, 34, 34,\n",
+       "                        35, 35, 36, 36, 37, 37, 38, 38, 39, 39, 40, 40, 41, 41,\n",
+       "                        42, 42, 43, 43, 44, 44, 45, 45, 46, 46, 47, 47, 48, 48,\n",
+       "                        49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55,\n",
+       "                        56, 56, 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 62, 62,\n",
+       "                        63, 63, 64, 64, 65, 65, 66, 66, 67, 67, 68, 68, 69, 69,\n",
+       "                        70, 70, 71, 71, 72, 72, 73, 73, 74, 74, 75, 75, 76, 76,\n",
+       "                        77, 77],\n",
+       "                       [ 0,  1,  0,  2,  0,  3,  0,  4,  0,  5,  0,  6,  0,  7,\n",
+       "                         0,  8,  0, 10,  0, 11,  0, 12,  0, 13,  0, 17,  0, 19,\n",
+       "                         0, 21,  0, 31,  1,  2,  1,  3,  1,  7,  1, 13,  1, 17,\n",
+       "                         1, 19,  1, 21,  1, 30,  2,  3,  2,  7,  2,  8,  2,  9,\n",
+       "                         2, 13,  2, 27,  2, 28,  2, 32,  3,  7,  3, 12,  3, 13,\n",
+       "                         4,  6,  4, 10,  5,  6,  5, 10,  5, 16,  6, 16,  8, 30,\n",
+       "                         8, 32,  8, 33,  9, 33, 13, 33, 14, 32, 14, 33, 15, 32,\n",
+       "                        15, 33, 18, 32, 18, 33, 19, 33, 20, 32, 20, 33, 22, 32,\n",
+       "                        22, 33, 23, 25, 23, 27, 23, 29, 23, 32, 23, 33, 24, 25,\n",
+       "                        24, 27, 24, 31, 25, 31, 26, 29, 26, 33, 27, 33, 28, 31,\n",
+       "                        28, 33, 29, 32, 29, 33, 30, 32, 30, 33, 31, 32, 31, 33,\n",
+       "                        32, 33]]),\n",
+       "       values=tensor([-1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,\n",
+       "                       1., -1.,  1., -1.,  1., -1.,  1., -1.,  1., -1.,  1.,\n",
+       "                      -1.,  1.]),\n",
+       "       size=(78, 34), nnz=156, layout=torch.sparse_coo)"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "incidence_1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KHCGA1gY0pEj"
+   },
+   "source": [
+    "## Import signal ##\n",
+    "\n",
+    "We define edge features to be the gradient of the nodes features, i.e. given the node feature matrix $X_0$, we compute the edge features matrix as $X_1 = B_1^TX_0$. We will finally obtain the estimated node labels from the updated edge features by multiplying them again with $B_1$, i.e. the final nodes features are computed as the divergence of the final edge features.\n",
+    "\n",
+    "**Remark.** Please notice that also this way of deriving edges/nodes features from nodes/edges features could be seen as a (non-learnable) message passing between rank-0/1 cells (nodes/edges) and rank-1/0 cells (nodes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {
+    "id": "EBf26K5N0pEj",
+    "outputId": "22acb245-384f-4d62-9e59-b55bdea3353e"
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(750, 750)\n",
-      "(750, 750)\n"
+      "There are 34 nodes with features of dimension 2.\n",
+      "There are 78 edges with features of dimension 2.\n",
+      "There are 45 faces with features of dimension 2.\n"
      ]
     }
    ],
    "source": [
-    "adjacency_1 = simplexes[13].adjacency_matrix(rank=1, signed=False)\n",
-    "incidence_1 = simplexes[13].incidence_matrix(rank=1, signed=False)\n",
+    "x_0 = []\n",
+    "for _, v in dataset.get_simplex_attributes(\"node_feat\").items():\n",
+    "    x_0.append(v)\n",
+    "x_0 = torch.tensor(np.stack(x_0))\n",
+    "channels_nodes = x_0.shape[-1]\n",
+    "print(f\"There are {x_0.shape[0]} nodes with features of dimension {x_0.shape[1]}.\")\n",
     "\n",
-    "# k = normalize_higher_order_adj(adjacency_1)\n",
-    "# print(k)\n",
+    "x_1 = []\n",
+    "for k, v in dataset.get_simplex_attributes(\"edge_feat\").items():\n",
+    "    x_1.append(v)\n",
+    "x_1 = torch.tensor(np.stack(x_1))\n",
+    "print(f\"There are {x_1.shape[0]} edges with features of dimension {x_1.shape[1]}.\")\n",
     "\n",
-    "print(adjacency_1.todense().shape)\n",
-    "k = normalize_higher_order_adj(adjacency_1)\n",
-    "print(k.todense().shape)"
+    "x_2 = []\n",
+    "for k, v in dataset.get_simplex_attributes(\"face_feat\").items():\n",
+    "    x_2.append(v)\n",
+    "x_2 = torch.tensor(np.stack(x_2))\n",
+    "print(f\"There are {x_2.shape[0]} faces with features of dimension {x_2.shape[1]}.\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "id": "PWQ_NRiU0pEl"
    },
    "source": [
-    "# Define Neighbourhood Structures\n",
-    "\n",
-    "We create the neigborood structures expected by SSConv. The SSConv layer expects the following neighbourhood structures:\n",
-    "* incidence_1 $B_1$\n",
-    "* incidence_1_norm $\\tilde{B}_1$\n",
-    "* incidence_2 $B_2$\n",
-    "* incidence_2_norm $\\tilde{B}_1$\n",
-    "* adjacency_up_0_norm $\\tilde{A}_{\\uparrow,0}$\n",
-    "* adjacency_up_1_norm $\\tilde{A}_{\\uparrow,1}$\n",
-    "* adjacency_down_1_norm $\\tilde{A}_{\\downarrow,1}$\n",
-    "* adjacency_down_2_norm $\\tilde{A}_{\\downarrow,2}$"
+    "Hence, the final input features are defined by this sum, and we also pre-define the number of hidden and output channels of the model."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 90,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-13T23:33:28.375213622Z",
-     "start_time": "2023-07-13T23:33:28.328016738Z"
-    },
-    "collapsed": false
+    "id": "cS7o2U620pEl"
    },
    "outputs": [],
    "source": [
-    "def get_neighborhoods(simplexes):\n",
-    "    incidence_1_list = []\n",
-    "    incidence_1_norm_list = []\n",
-    "    incidence_2_list = []\n",
-    "    incidence_2_norm_list = []\n",
-    "    adjacency_up_0_norm_list = []\n",
-    "    adjacency_up_1_norm_list = []\n",
-    "    adjacency_down_1_norm_list = []\n",
-    "    adjacency_down_2_norm_list = []\n",
-    "\n",
-    "    # incidence_1_list = []\n",
-    "    # incidence_2_list = []\n",
-    "    # up_laplacian_1_list = []\n",
-    "    # up_laplacian_2_list = []\n",
-    "    # down_laplacian_1_list = []\n",
-    "    # down_laplacian_2_list = []\n",
-    "    # for simplex in simplexes:\n",
-    "    #     B1 = simplex.incidence_matrix(rank=1, signed=False)\n",
-    "    #     B2 = simplex.incidence_matrix(rank=2, signed=False)\n",
-    "    #\n",
-    "    #     up_laplacian_1 = simplex.up_laplacian_matrix(rank=0)  #1\n",
-    "    #     up_laplacian_2 = simplex.up_laplacian_matrix(rank=1)  #2\n",
-    "    #\n",
-    "    #     down_laplacian_1 = simplex.down_laplacian_matrix(rank=1)  #1\n",
-    "    #     down_laplacian_2 = simplex.down_laplacian_matrix(rank=2)  #2\n",
-    "    #\n",
-    "    #     incidence_1 = from_sparse(B1)\n",
-    "    #     incidence_2 = from_sparse(B2)\n",
-    "    #\n",
-    "    #     up_laplacian_1 = from_sparse(up_laplacian_1)\n",
-    "    #     up_laplacian_2 = from_sparse(up_laplacian_2)\n",
-    "    #\n",
-    "    #     down_laplacian_1 = from_sparse(down_laplacian_1)\n",
-    "    #     down_laplacian_2 = from_sparse(down_laplacian_2)\n",
-    "    #\n",
-    "    #     incidence_1_list.append(incidence_1)\n",
-    "    #     incidence_2_list.append(incidence_2)\n",
-    "    #     up_laplacian_1_list.append(up_laplacian_1)\n",
-    "    #     up_laplacian_2_list.append(up_laplacian_2)\n",
-    "    #     down_laplacian_1_list.append(down_laplacian_1)\n",
-    "    #     down_laplacian_2_list.append(down_laplacian_2)\n",
-    "\n",
-    "    return (\n",
-    "        incidence_1_list,\n",
-    "        incidence_1_norm_list,\n",
-    "        incidence_2_list,\n",
-    "        incidence_2_norm_list,\n",
-    "        adjacency_up_0_norm_list,\n",
-    "        adjacency_up_1_norm_list,\n",
-    "        adjacency_down_1_norm_list,\n",
-    "        adjacency_down_2_norm_list,\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "(\n",
-    "    incidence_1_list,\n",
-    "    incidence_1_norm_list,\n",
-    "    incidence_2_list,\n",
-    "    incidence_2_norm_list,\n",
-    "    adjacency_up_0_norm_list,\n",
-    "    adjacency_up_1_norm_list,\n",
-    "    adjacency_down_1_norm_list,\n",
-    "    adjacency_down_2_norm_list,\n",
-    ") = get_neighborhoods(simplexes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Create and Train the Neural Network"
+    "in_channels = x_0.shape[-1]\n",
+    "out_channels = 2"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "id": "WDnM5N2G0pEl"
    },
    "source": [
-    "## prepare training and test data"
+    "## Define binary labels\n",
+    "We retrieve the labels associated to the nodes of each input simplex. In the KarateClub dataset, two social groups emerge. So we assign binary labels to the nodes indicating of which group they are a part.\n",
+    "\n",
+    "We convert one-hot encode the binary labels, and keep the first four nodes for the purpose of testing."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 91,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-13T23:54:20.825930864Z",
-     "start_time": "2023-07-13T23:54:20.783159857Z"
-    }
+    "id": "Ub-GWaMm0pEl"
    },
    "outputs": [],
    "source": [
-    "# ToDo: apply train/test splitting\n",
-    "\n",
-    "x_0_train = x_0s\n",
-    "x_1_train = x_1s\n",
-    "x_2_train = x_2s\n",
-    "\n",
-    "(\n",
-    "    incidence_1_list,\n",
-    "    incidence_1_norm_list,\n",
-    "    incidence_2_list,\n",
-    "    incidence_2_norm_list,\n",
-    "    adjacency_up_0_norm_list,\n",
-    "    adjacency_up_1_norm_list,\n",
-    "    adjacency_down_1_norm_list,\n",
-    "    adjacency_down_2_norm_list,\n",
-    ") = get_neighborhoods(simplexes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-13T23:57:13.419769194Z",
-     "start_time": "2023-07-13T23:57:12.242273643Z"
-    },
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "model = SCConv(\n",
-    "    node_channels=x_0s[0].shape[1],\n",
-    "    edge_channels=x_1s[0].shape[1],\n",
-    "    face_channels=x_1s[0].shape[1],\n",
-    "    n_classes=len(np.unique(ys)),\n",
-    "    n_layers=2,\n",
+    "y = np.array(\n",
+    "    [\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        0,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        1,\n",
+    "        0,\n",
+    "        0,\n",
+    "        1,\n",
+    "        1,\n",
+    "        0,\n",
+    "        1,\n",
+    "        0,\n",
+    "        1,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "        0,\n",
+    "    ]\n",
     ")\n",
-    "model = model.to(device)\n",
-    "opt = torch.optim.Adam(model.parameters(), lr=0.1)\n",
-    "loss_fn = torch.nn.MSELoss()"
+    "y_true = np.zeros((34, 2))\n",
+    "y_true[:, 0] = y\n",
+    "y_true[:, 1] = 1 - y\n",
+    "y_train = y_true[:30]\n",
+    "y_test = y_true[-4:]\n",
+    "\n",
+    "y_train = torch.from_numpy(y_train)\n",
+    "y_test = torch.from_numpy(y_test)"
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "wTHtR74f0pEl"
+   },
+   "source": [
+    "# Create the Neural Network\n",
+    "\n",
+    "Using the SAN class, we create our neural network with stacked layers. Given the considered dataset and task (Karate Club, node classification), a linear layer at the end produces an output with shape $n_\\text{nodes} \\times 2$, so we can compare with our binary labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Network(torch.nn.Module):\n",
+    "    def __init__(self, in_channels, out_channels, n_layers=1):\n",
+    "        super(Network, self).__init__()\n",
+    "        self.base_model = SCConv(\n",
+    "            node_channels=in_channels,\n",
+    "            n_layers=n_layers,\n",
+    "        )\n",
+    "        self.linear_x0 = torch.nn.Linear(in_channels, out_channels)\n",
+    "        self.linear_x1 = torch.nn.Linear(in_channels, out_channels)\n",
+    "        self.linear_x2 = torch.nn.Linear(in_channels, out_channels)\n",
+    "\n",
+    "    def forward(\n",
+    "        self,\n",
+    "        x_0,\n",
+    "        x_1,\n",
+    "        x_2,\n",
+    "        incidence_1,\n",
+    "        incidence_1_norm,\n",
+    "        incidence_2,\n",
+    "        incidence_2_norm,\n",
+    "        adjacency_up_0_norm,\n",
+    "        adjacency_up_1_norm,\n",
+    "        adjacency_down_1_norm,\n",
+    "        adjacency_down_2_norm,\n",
+    "    ):\n",
+    "        x_0, x_1, x_2 = self.base_model(\n",
+    "            x_0,\n",
+    "            x_1,\n",
+    "            x_2,\n",
+    "            incidence_1,\n",
+    "            incidence_1_norm,\n",
+    "            incidence_2,\n",
+    "            incidence_2_norm,\n",
+    "            adjacency_up_0_norm,\n",
+    "            adjacency_up_1_norm,\n",
+    "            adjacency_down_1_norm,\n",
+    "            adjacency_down_2_norm,\n",
+    "        )\n",
+    "        x_0 = self.linear_x0(x_0)\n",
+    "        x_1 = self.linear_x1(x_1)\n",
+    "        x_2 = self.linear_x2(x_2)\n",
+    "        return torch.softmax(x_0, dim=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_layers = 1\n",
+    "model = Network(\n",
+    "    in_channels=in_channels,\n",
+    "    out_channels=out_channels,\n",
+    "    n_layers=n_layers,\n",
+    ")\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3UEoWB2G0pEm"
+   },
+   "source": [
+    "# Train the Neural Network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nNOcultR0pEm"
+   },
    "source": [
     "The following cell performs the training, looping over the network for a low number of epochs."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 102,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-07-14T00:07:17.739647566Z",
-     "start_time": "2023-07-14T00:07:17.696911071Z"
-    }
+    "id": "sWopn2U60pEn",
+    "outputId": "a2153bef-91eb-4f99-8aad-3166b4966c26"
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch: 1 loss: nan\n",
-      "Epoch: 2 loss: nan\n",
-      "Epoch: 3 loss: nan\n",
-      "Epoch: 4 loss: nan\n",
-      "Epoch: 5 loss: nan\n"
+      "Epoch: 1 loss: 0.7134 Train_acc: 0.5667\n",
+      "Epoch: 2 loss: 0.7133 Train_acc: 0.5667\n",
+      "Epoch: 3 loss: 0.7132 Train_acc: 0.5667\n",
+      "Epoch: 4 loss: 0.7131 Train_acc: 0.5667\n",
+      "Epoch: 5 loss: 0.7128 Train_acc: 0.5667\n",
+      "Epoch: 6 loss: 0.7125 Train_acc: 0.5667\n",
+      "Epoch: 7 loss: 0.7120 Train_acc: 0.5667\n",
+      "Epoch: 8 loss: 0.7117 Train_acc: 0.5667\n",
+      "Epoch: 9 loss: 0.7113 Train_acc: 0.5667\n",
+      "Epoch: 10 loss: 0.7109 Train_acc: 0.5667\n",
+      "Test_acc: 0.0000\n",
+      "Epoch: 11 loss: 0.7105 Train_acc: 0.5667\n",
+      "Epoch: 12 loss: 0.7099 Train_acc: 0.5667\n",
+      "Epoch: 13 loss: 0.7093 Train_acc: 0.5667\n",
+      "Epoch: 14 loss: 0.7086 Train_acc: 0.5667\n",
+      "Epoch: 15 loss: 0.7079 Train_acc: 0.5667\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.11/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice.\n",
-      "  return _methods._mean(a, axis=axis, dtype=dtype,\n",
-      "/usr/local/lib/python3.11/site-packages/numpy/core/_methods.py:129: RuntimeWarning: invalid value encountered in scalar divide\n",
-      "  ret = ret.dtype.type(ret / rcount)\n"
+      "Epoch: 16 loss: 0.7070 Train_acc: 0.5667\n",
+      "Epoch: 17 loss: 0.7062 Train_acc: 0.5667\n",
+      "Epoch: 18 loss: 0.7052 Train_acc: 0.5667\n",
+      "Epoch: 19 loss: 0.7042 Train_acc: 0.5667\n",
+      "Epoch: 20 loss: 0.7030 Train_acc: 0.5667\n",
+      "Test_acc: 0.0000\n",
+      "Epoch: 21 loss: 0.7017 Train_acc: 0.5667\n",
+      "Epoch: 22 loss: 0.7003 Train_acc: 0.5667\n",
+      "Epoch: 23 loss: 0.6988 Train_acc: 0.5667\n",
+      "Epoch: 24 loss: 0.6971 Train_acc: 0.5667\n",
+      "Epoch: 25 loss: 0.6954 Train_acc: 0.5667\n",
+      "Epoch: 26 loss: 0.6935 Train_acc: 0.5667\n",
+      "Epoch: 27 loss: 0.6916 Train_acc: 0.5667\n",
+      "Epoch: 28 loss: 0.6894 Train_acc: 0.5667\n",
+      "Epoch: 29 loss: 0.6872 Train_acc: 0.5667\n",
+      "Epoch: 30 loss: 0.6849 Train_acc: 0.5667\n",
+      "Test_acc: 0.5000\n",
+      "Epoch: 31 loss: 0.6824 Train_acc: 0.6000\n",
+      "Epoch: 32 loss: 0.6799 Train_acc: 0.6000\n",
+      "Epoch: 33 loss: 0.6772 Train_acc: 0.6333\n",
+      "Epoch: 34 loss: 0.6745 Train_acc: 0.6333\n",
+      "Epoch: 35 loss: 0.6716 Train_acc: 0.6667\n",
+      "Epoch: 36 loss: 0.6687 Train_acc: 0.7000\n",
+      "Epoch: 37 loss: 0.6657 Train_acc: 0.7333\n",
+      "Epoch: 38 loss: 0.6626 Train_acc: 0.7333\n",
+      "Epoch: 39 loss: 0.6596 Train_acc: 0.7667\n",
+      "Epoch: 40 loss: 0.6564 Train_acc: 0.9333\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 41 loss: 0.6533 Train_acc: 0.9667\n",
+      "Epoch: 42 loss: 0.6501 Train_acc: 0.9333\n",
+      "Epoch: 43 loss: 0.6469 Train_acc: 0.9333\n",
+      "Epoch: 44 loss: 0.6437 Train_acc: 0.9333\n",
+      "Epoch: 45 loss: 0.6406 Train_acc: 0.9333\n",
+      "Epoch: 46 loss: 0.6374 Train_acc: 0.9333\n",
+      "Epoch: 47 loss: 0.6343 Train_acc: 0.9667\n",
+      "Epoch: 48 loss: 0.6313 Train_acc: 0.9667\n",
+      "Epoch: 49 loss: 0.6282 Train_acc: 0.9667\n",
+      "Epoch: 50 loss: 0.6253 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 51 loss: 0.6223 Train_acc: 0.9667\n",
+      "Epoch: 52 loss: 0.6195 Train_acc: 0.9667\n",
+      "Epoch: 53 loss: 0.6167 Train_acc: 0.9667\n",
+      "Epoch: 54 loss: 0.6140 Train_acc: 0.9667\n",
+      "Epoch: 55 loss: 0.6113 Train_acc: 0.9667\n",
+      "Epoch: 56 loss: 0.6087 Train_acc: 0.9667\n",
+      "Epoch: 57 loss: 0.6062 Train_acc: 0.9667\n",
+      "Epoch: 58 loss: 0.6038 Train_acc: 0.9667\n",
+      "Epoch: 59 loss: 0.6014 Train_acc: 0.9667\n",
+      "Epoch: 60 loss: 0.5991 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 61 loss: 0.5969 Train_acc: 0.9667\n",
+      "Epoch: 62 loss: 0.5948 Train_acc: 0.9667\n",
+      "Epoch: 63 loss: 0.5927 Train_acc: 0.9667\n",
+      "Epoch: 64 loss: 0.5907 Train_acc: 0.9667\n",
+      "Epoch: 65 loss: 0.5887 Train_acc: 0.9667\n",
+      "Epoch: 66 loss: 0.5869 Train_acc: 0.9667\n",
+      "Epoch: 67 loss: 0.5851 Train_acc: 0.9667\n",
+      "Epoch: 68 loss: 0.5833 Train_acc: 0.9667\n",
+      "Epoch: 69 loss: 0.5817 Train_acc: 0.9667\n",
+      "Epoch: 70 loss: 0.5801 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 71 loss: 0.5785 Train_acc: 0.9667\n",
+      "Epoch: 72 loss: 0.5770 Train_acc: 0.9667\n",
+      "Epoch: 73 loss: 0.5756 Train_acc: 0.9667\n",
+      "Epoch: 74 loss: 0.5742 Train_acc: 0.9667\n",
+      "Epoch: 75 loss: 0.5728 Train_acc: 0.9667\n",
+      "Epoch: 76 loss: 0.5715 Train_acc: 0.9667\n",
+      "Epoch: 77 loss: 0.5703 Train_acc: 0.9667\n",
+      "Epoch: 78 loss: 0.5691 Train_acc: 0.9667\n",
+      "Epoch: 79 loss: 0.5679 Train_acc: 0.9667\n",
+      "Epoch: 80 loss: 0.5668 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 81 loss: 0.5657 Train_acc: 0.9667\n",
+      "Epoch: 82 loss: 0.5647 Train_acc: 0.9667\n",
+      "Epoch: 83 loss: 0.5637 Train_acc: 0.9667\n",
+      "Epoch: 84 loss: 0.5627 Train_acc: 0.9667\n",
+      "Epoch: 85 loss: 0.5618 Train_acc: 0.9667\n",
+      "Epoch: 86 loss: 0.5609 Train_acc: 0.9667\n",
+      "Epoch: 87 loss: 0.5601 Train_acc: 0.9667\n",
+      "Epoch: 88 loss: 0.5592 Train_acc: 0.9667\n",
+      "Epoch: 89 loss: 0.5584 Train_acc: 0.9667\n",
+      "Epoch: 90 loss: 0.5577 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 91 loss: 0.5569 Train_acc: 0.9667\n",
+      "Epoch: 92 loss: 0.5562 Train_acc: 0.9667\n",
+      "Epoch: 93 loss: 0.5555 Train_acc: 0.9667\n",
+      "Epoch: 94 loss: 0.5548 Train_acc: 0.9667\n",
+      "Epoch: 95 loss: 0.5542 Train_acc: 0.9667\n",
+      "Epoch: 96 loss: 0.5535 Train_acc: 0.9667\n",
+      "Epoch: 97 loss: 0.5529 Train_acc: 0.9667\n",
+      "Epoch: 98 loss: 0.5523 Train_acc: 0.9667\n",
+      "Epoch: 99 loss: 0.5518 Train_acc: 0.9667\n",
+      "Epoch: 100 loss: 0.5512 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 101 loss: 0.5507 Train_acc: 0.9667\n",
+      "Epoch: 102 loss: 0.5502 Train_acc: 0.9667\n",
+      "Epoch: 103 loss: 0.5497 Train_acc: 0.9667\n",
+      "Epoch: 104 loss: 0.5492 Train_acc: 0.9667\n",
+      "Epoch: 105 loss: 0.5487 Train_acc: 0.9667\n",
+      "Epoch: 106 loss: 0.5483 Train_acc: 0.9667\n",
+      "Epoch: 107 loss: 0.5478 Train_acc: 0.9667\n",
+      "Epoch: 108 loss: 0.5474 Train_acc: 0.9667\n",
+      "Epoch: 109 loss: 0.5470 Train_acc: 0.9667\n",
+      "Epoch: 110 loss: 0.5466 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 111 loss: 0.5462 Train_acc: 0.9667\n",
+      "Epoch: 112 loss: 0.5458 Train_acc: 0.9667\n",
+      "Epoch: 113 loss: 0.5455 Train_acc: 0.9667\n",
+      "Epoch: 114 loss: 0.5451 Train_acc: 0.9667\n",
+      "Epoch: 115 loss: 0.5448 Train_acc: 0.9667\n",
+      "Epoch: 116 loss: 0.5444 Train_acc: 0.9667\n",
+      "Epoch: 117 loss: 0.5441 Train_acc: 0.9667\n",
+      "Epoch: 118 loss: 0.5438 Train_acc: 0.9667\n",
+      "Epoch: 119 loss: 0.5435 Train_acc: 0.9667\n",
+      "Epoch: 120 loss: 0.5432 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 121 loss: 0.5429 Train_acc: 0.9667\n",
+      "Epoch: 122 loss: 0.5426 Train_acc: 0.9667\n",
+      "Epoch: 123 loss: 0.5423 Train_acc: 0.9667\n",
+      "Epoch: 124 loss: 0.5421 Train_acc: 0.9667\n",
+      "Epoch: 125 loss: 0.5418 Train_acc: 0.9667\n",
+      "Epoch: 126 loss: 0.5416 Train_acc: 0.9667\n",
+      "Epoch: 127 loss: 0.5413 Train_acc: 0.9667\n",
+      "Epoch: 128 loss: 0.5411 Train_acc: 0.9667\n",
+      "Epoch: 129 loss: 0.5408 Train_acc: 0.9667\n",
+      "Epoch: 130 loss: 0.5406 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 131 loss: 0.5404 Train_acc: 0.9667\n",
+      "Epoch: 132 loss: 0.5402 Train_acc: 0.9667\n",
+      "Epoch: 133 loss: 0.5400 Train_acc: 0.9667\n",
+      "Epoch: 134 loss: 0.5398 Train_acc: 0.9667\n",
+      "Epoch: 135 loss: 0.5395 Train_acc: 0.9667\n",
+      "Epoch: 136 loss: 0.5393 Train_acc: 0.9667\n",
+      "Epoch: 137 loss: 0.5392 Train_acc: 0.9667\n",
+      "Epoch: 138 loss: 0.5390 Train_acc: 0.9667\n",
+      "Epoch: 139 loss: 0.5388 Train_acc: 0.9667\n",
+      "Epoch: 140 loss: 0.5386 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 141 loss: 0.5384 Train_acc: 0.9667\n",
+      "Epoch: 142 loss: 0.5383 Train_acc: 0.9667\n",
+      "Epoch: 143 loss: 0.5381 Train_acc: 0.9667\n",
+      "Epoch: 144 loss: 0.5379 Train_acc: 0.9667\n",
+      "Epoch: 145 loss: 0.5378 Train_acc: 0.9667\n",
+      "Epoch: 146 loss: 0.5376 Train_acc: 0.9667\n",
+      "Epoch: 147 loss: 0.5374 Train_acc: 0.9667\n",
+      "Epoch: 148 loss: 0.5373 Train_acc: 0.9667\n",
+      "Epoch: 149 loss: 0.5371 Train_acc: 0.9667\n",
+      "Epoch: 150 loss: 0.5370 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 151 loss: 0.5369 Train_acc: 0.9667\n",
+      "Epoch: 152 loss: 0.5367 Train_acc: 0.9667\n",
+      "Epoch: 153 loss: 0.5366 Train_acc: 0.9667\n",
+      "Epoch: 154 loss: 0.5364 Train_acc: 0.9667\n",
+      "Epoch: 155 loss: 0.5363 Train_acc: 0.9667\n",
+      "Epoch: 156 loss: 0.5362 Train_acc: 0.9667\n",
+      "Epoch: 157 loss: 0.5361 Train_acc: 0.9667\n",
+      "Epoch: 158 loss: 0.5359 Train_acc: 0.9667\n",
+      "Epoch: 159 loss: 0.5358 Train_acc: 0.9667\n",
+      "Epoch: 160 loss: 0.5357 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 161 loss: 0.5356 Train_acc: 0.9667\n",
+      "Epoch: 162 loss: 0.5355 Train_acc: 0.9667\n",
+      "Epoch: 163 loss: 0.5354 Train_acc: 0.9667\n",
+      "Epoch: 164 loss: 0.5352 Train_acc: 0.9667\n",
+      "Epoch: 165 loss: 0.5351 Train_acc: 0.9667\n",
+      "Epoch: 166 loss: 0.5350 Train_acc: 0.9667\n",
+      "Epoch: 167 loss: 0.5349 Train_acc: 0.9667\n",
+      "Epoch: 168 loss: 0.5348 Train_acc: 0.9667\n",
+      "Epoch: 169 loss: 0.5347 Train_acc: 0.9667\n",
+      "Epoch: 170 loss: 0.5346 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 171 loss: 0.5345 Train_acc: 0.9667\n",
+      "Epoch: 172 loss: 0.5344 Train_acc: 0.9667\n",
+      "Epoch: 173 loss: 0.5343 Train_acc: 0.9667\n",
+      "Epoch: 174 loss: 0.5342 Train_acc: 0.9667\n",
+      "Epoch: 175 loss: 0.5341 Train_acc: 0.9667\n",
+      "Epoch: 176 loss: 0.5341 Train_acc: 0.9667\n",
+      "Epoch: 177 loss: 0.5340 Train_acc: 0.9667\n",
+      "Epoch: 178 loss: 0.5339 Train_acc: 0.9667\n",
+      "Epoch: 179 loss: 0.5338 Train_acc: 0.9667\n",
+      "Epoch: 180 loss: 0.5337 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 181 loss: 0.5336 Train_acc: 0.9667\n",
+      "Epoch: 182 loss: 0.5335 Train_acc: 0.9667\n",
+      "Epoch: 183 loss: 0.5335 Train_acc: 0.9667\n",
+      "Epoch: 184 loss: 0.5334 Train_acc: 0.9667\n",
+      "Epoch: 185 loss: 0.5333 Train_acc: 0.9667\n",
+      "Epoch: 186 loss: 0.5332 Train_acc: 0.9667\n",
+      "Epoch: 187 loss: 0.5332 Train_acc: 0.9667\n",
+      "Epoch: 188 loss: 0.5331 Train_acc: 0.9667\n",
+      "Epoch: 189 loss: 0.5330 Train_acc: 0.9667\n",
+      "Epoch: 190 loss: 0.5329 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n",
+      "Epoch: 191 loss: 0.5329 Train_acc: 0.9667\n",
+      "Epoch: 192 loss: 0.5328 Train_acc: 0.9667\n",
+      "Epoch: 193 loss: 0.5327 Train_acc: 0.9667\n",
+      "Epoch: 194 loss: 0.5327 Train_acc: 0.9667\n",
+      "Epoch: 195 loss: 0.5326 Train_acc: 0.9667\n",
+      "Epoch: 196 loss: 0.5325 Train_acc: 0.9667\n",
+      "Epoch: 197 loss: 0.5325 Train_acc: 0.9667\n",
+      "Epoch: 198 loss: 0.5324 Train_acc: 0.9667\n",
+      "Epoch: 199 loss: 0.5323 Train_acc: 0.9667\n",
+      "Epoch: 200 loss: 0.5323 Train_acc: 0.9667\n",
+      "Test_acc: 1.0000\n"
      ]
     }
    ],
    "source": [
-    "test_interval = 1\n",
-    "num_epochs = 5\n",
-    "\n",
+    "test_interval = 10\n",
+    "num_epochs = 200\n",
     "for epoch_i in range(1, num_epochs + 1):\n",
     "    epoch_loss = []\n",
     "    model.train()\n",
-    "    for (\n",
+    "    optimizer.zero_grad()\n",
+    "\n",
+    "    y_hat = model(\n",
     "        x_0,\n",
     "        x_1,\n",
     "        x_2,\n",
-    "        incid1,\n",
-    "        incid1_norm,\n",
-    "        incid2,\n",
-    "        incid2_norm,\n",
-    "        adj0_up_norm,\n",
-    "        adj1_up_norm,\n",
-    "        adj1_down_norm,\n",
-    "        adj2_down_norm,\n",
-    "        y,\n",
-    "    ) in zip(\n",
-    "        x_0_train,\n",
-    "        x_1_train,\n",
-    "        x_2_train,\n",
-    "        incidence_1_list,\n",
-    "        incidence_1_norm_list,\n",
-    "        incidence_2_list,\n",
-    "        incidence_2_norm_list,\n",
-    "        adjacency_up_0_norm_list,\n",
-    "        adjacency_up_1_norm_list,\n",
-    "        adjacency_down_1_norm_list,\n",
-    "        adjacency_down_2_norm_list,\n",
-    "        ys,\n",
-    "    ):\n",
-    "        (\n",
-    "            x_0,\n",
-    "            x_1,\n",
-    "            x_2,\n",
-    "            y,\n",
-    "            incid1,\n",
-    "            incid1_norm,\n",
-    "            incid2,\n",
-    "            incid2_norm,\n",
-    "            adj0_up_norm,\n",
-    "            adj1_up_norm,\n",
-    "            adj1_down_norm,\n",
-    "            adj2_down_norm,\n",
-    "        ) = (\n",
-    "            torch.tensor(x_0).float().to(device),\n",
-    "            torch.tensor(x_1).float().to(device),\n",
-    "            torch.tensor(x_2).float().to(device),\n",
-    "            torch.tensor(y).float().to(device),\n",
-    "            incid1.float().to(device),\n",
-    "            incid1_norm.float().to(device),\n",
-    "            incid2.float().to(device),\n",
-    "            incid2_norm.float().to(device),\n",
-    "            adj0_up_norm.float().to(device),\n",
-    "            adj1_up_norm.float().to(device),\n",
-    "            adj1_down_norm.float().to(device),\n",
-    "            adj2_down_norm.float().to(device),\n",
-    "        )\n",
+    "        incidence_1,\n",
+    "        incidence_1_norm,\n",
+    "        incidence_2,\n",
+    "        incidence_2_norm,\n",
+    "        adjacency_up_0_norm,\n",
+    "        adjacency_up_1_norm,\n",
+    "        adjacency_down_1_norm,\n",
+    "        adjacency_down_2_norm,\n",
+    "    )\n",
+    "    # We project the edge-level output of the model to the node-level\n",
+    "    # and apply softmax fn to get the final node-level classification output\n",
+    "    # y_hat = torch.softmax(torch.sparse.mm(incidence_0_1, y_hat_edge), dim=1)\n",
+    "    loss = torch.nn.functional.binary_cross_entropy_with_logits(\n",
+    "        y_hat[: len(y_train)].float(), y_train.float()\n",
+    "    )\n",
+    "    epoch_loss.append(loss.item())\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
     "\n",
-    "        opt.zero_grad()\n",
-    "        y_hat = model(\n",
-    "            x_0,\n",
-    "            x_1,\n",
-    "            x_2,\n",
-    "            y,\n",
-    "            incid1,\n",
-    "            incid1_norm,\n",
-    "            incid2,\n",
-    "            incid2_norm,\n",
-    "            adj0_up_norm,\n",
-    "            adj1_up_norm,\n",
-    "            adj1_down_norm,\n",
-    "            adj2_down_norm,\n",
-    "        )\n",
-    "        print(y_hat)\n",
-    "        loss = loss_fn(y_hat.flatten(), y)\n",
-    "        loss.backward()\n",
-    "\n",
-    "        opt.step()\n",
-    "        epoch_loss.append(loss.item())\n",
-    "\n",
+    "    y_pred = torch.where(y_hat > 0.5, torch.tensor(1), torch.tensor(0))\n",
+    "    accuracy = (y_pred[: len(y_train)] == y_train).all(dim=1).float().mean().item()\n",
     "    print(\n",
-    "        f\"Epoch: {epoch_i} loss: {np.mean(epoch_loss)}\",\n",
+    "        f\"Epoch: {epoch_i} loss: {np.mean(epoch_loss):.4f} Train_acc: {accuracy:.4f}\",\n",
     "        flush=True,\n",
     "    )\n",
-    "\n",
     "    if epoch_i % test_interval == 0:\n",
-    "        correct_count = 0\n",
     "        with torch.no_grad():\n",
-    "            for (\n",
-    "                x_0t,\n",
-    "                x_1t,\n",
-    "                x_2t,\n",
-    "                incid1t,\n",
-    "                incid1_normt,\n",
-    "                incid2t,\n",
-    "                incid2_normt,\n",
-    "                adj0_up_normt,\n",
-    "                adj1_up_normt,\n",
-    "                adj1_down_normt,\n",
-    "                adj2_down_normt,\n",
-    "                yt,\n",
-    "            ) in zip(\n",
-    "                x_0_train,\n",
-    "                x_1_train,\n",
-    "                x_2_train,\n",
-    "                incidence_1_list,\n",
-    "                incidence_1_norm_list,\n",
-    "                incidence_2_list,\n",
-    "                incidence_2_norm_list,\n",
-    "                adjacency_up_0_norm_list,\n",
-    "                adjacency_up_1_norm_list,\n",
-    "                adjacency_down_1_norm_list,\n",
-    "                adjacency_down_2_norm_list,\n",
-    "                ys,\n",
-    "            ):\n",
-    "                (\n",
-    "                    x_0t,\n",
-    "                    x_1t,\n",
-    "                    x_2t,\n",
-    "                    yt,\n",
-    "                    incid1t,\n",
-    "                    incid1_normt,\n",
-    "                    incid2t,\n",
-    "                    incid2_normt,\n",
-    "                    adj0_up_normt,\n",
-    "                    adj1_up_normt,\n",
-    "                    adj1_down_norm,\n",
-    "                    adj2_down_norm,\n",
-    "                ) = (\n",
-    "                    torch.tensor(x_0t).float().to(device),\n",
-    "                    torch.tensor(x_1t).float().to(device),\n",
-    "                    torch.tensor(x_2t).float().to(device),\n",
-    "                    torch.tensor(yt).float().to(device),\n",
-    "                    incid1t.float().to(device),\n",
-    "                    incid1_normt.float().to(device),\n",
-    "                    incid2t.float().to(device),\n",
-    "                    incid2_normt.float().to(device),\n",
-    "                    adj0_up_normt.float().to(device),\n",
-    "                    adj1_up_normt.float().to(device),\n",
-    "                    adj1_down_normt.float().to(device),\n",
-    "                    adj2_down_normt.float().to(device),\n",
-    "                )\n",
-    "\n",
-    "                y_hat = model(\n",
-    "                    x_0t,\n",
-    "                    x_1t,\n",
-    "                    x_2t,\n",
-    "                    yt,\n",
-    "                    incid1t,\n",
-    "                    incid1_normt,\n",
-    "                    incid2t,\n",
-    "                    incid2_normt,\n",
-    "                    adj0_up_normt,\n",
-    "                    adj1_up_normt,\n",
-    "                    adj1_down_normt,\n",
-    "                    adj2_down_normt,\n",
-    "                )\n",
-    "                test_loss = loss_fn(y_hat, yt)\n",
-    "\n",
-    "                if round(y_hat.item()) == round(yt.item()):\n",
-    "                    correct_count += 1\n",
-    "\n",
-    "                print(f\"Test_loss: {test_loss}\", flush=True)"
+    "            y_hat_test = model(\n",
+    "                x_0,\n",
+    "                x_1,\n",
+    "                x_2,\n",
+    "                incidence_1,\n",
+    "                incidence_1_norm,\n",
+    "                incidence_2,\n",
+    "                incidence_2_norm,\n",
+    "                adjacency_up_0_norm,\n",
+    "                adjacency_up_1_norm,\n",
+    "                adjacency_down_1_norm,\n",
+    "                adjacency_down_2_norm,\n",
+    "            )\n",
+    "            y_pred_test = torch.where(\n",
+    "                y_hat_test > 0.5, torch.tensor(1), torch.tensor(0)\n",
+    "            )\n",
+    "            # _pred_test = torch.softmax(y_hat_test,dim=1).ge(0.5).float()\n",
+    "            test_accuracy = (\n",
+    "                torch.eq(y_pred_test[-len(y_test) :], y_test)\n",
+    "                .all(dim=1)\n",
+    "                .float()\n",
+    "                .mean()\n",
+    "                .item()\n",
+    "            )\n",
+    "            print(f\"Test_acc: {test_accuracy:.4f}\", flush=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "colab": {
+   "provenance": []
+  },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.11.3 ('topox')",
    "language": "python",
    "name": "python3"
   },
@@ -678,8 +858,13 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "7b696409e3d9b84bb97012e0a2d03075417bfa260eb8ad887be094cb925d5d5d"
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
This PR mainly modifies `SCConv` and `SCACMPS` tutorials and models to make them work. In our previous `simplicial_checks` PR we did not modify them because their tutorials needed to be re-written from scratch. 

Now they both run without problems using the Karate Club dataset. However, `SCConv` model still needs further revisions as the procedure to normalize the adjacencies is not properly working. In addition to this, `SSConv` related incidence and adjacency notations are missleading; they may need to be reformulated, the current version is difficult to understand.