### PR TITLE
Exclude `__init__` docstring validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,4 +130,5 @@ checks = [
 ]
 exclude = [
     '\.undocumented_method$',
+    '\.__init__$',
 ]


### PR DESCRIPTION
The `__init__` method is documented as part of the class docstrings. 

This PR is related to pyt-team/TopoNetX#342.