### PR TITLE
Update the Input Logic of Cell Complex Models

### DIFF
--- a/topomodelx/nn/cell/can.py
+++ b/topomodelx/nn/cell/can.py
@@ -31,8 +31,12 @@ class CAN(torch.nn.Module):
         Number of CAN layers.
     att_lift : bool, default=True
         Whether to apply a lift the signal from node-level to edge-level input.
+    pooling : bool, default=False
+        Whether to apply pooling operation.
     k_pool : float, default=0.5
         The pooling ratio i.e, the fraction of r-cells to keep after the pooling operation.
+    **kwargs : optional
+        Additional arguments CANLayer.
 
     References
     ----------
@@ -54,7 +58,9 @@ class CAN(torch.nn.Module):
         att_activation=None,
         n_layers=2,
         att_lift=True,
+        pooling=False,
         k_pool=0.5,
+        **kwargs,
     ):
         super().__init__()
 
@@ -81,6 +87,7 @@ class CAN(torch.nn.Module):
                 att_activation=att_activation,
                 aggr_func="sum",
                 update_func="relu",
+                **kwargs,
             )
         )
 
@@ -96,23 +103,23 @@ class CAN(torch.nn.Module):
                     att_activation=att_activation,
                     aggr_func="sum",
                     update_func="relu",
+                    **kwargs,
                 )
             )
-
-            layers.append(
-                PoolLayer(
-                    k_pool=k_pool,
-                    in_channels_0=out_channels * heads,
-                    signal_pool_activation=torch.nn.Sigmoid(),
-                    readout=True,
+            if pooling:
+                layers.append(
+                    PoolLayer(
+                        k_pool=k_pool,
+                        in_channels_0=out_channels * heads,
+                        signal_pool_activation=torch.nn.Sigmoid(),
+                        readout=True,
+                        **kwargs,
+                    )
                 )
-            )
 
         self.layers = torch.nn.ModuleList(layers)
 
-    def forward(
-        self, x_0, x_1, neighborhood_0_to_0, lower_neighborhood, upper_neighborhood
-    ):
+    def forward(self, x_0, x_1, adjacency_0, down_laplacian_1, up_laplacian_1):
         """Forward pass.
 
         Parameters
@@ -121,11 +128,11 @@ class CAN(torch.nn.Module):
             Input features on the nodes (0-cells).
         x_1 : torch.Tensor, shape = (n_edges, in_channels_1)
             Input features on the edges (1-cells).
-        neighborhood_0_to_0 : torch.Tensor, shape = (n_nodes, n_nodes)
+        adjacency_0 : torch.Tensor, shape = (n_nodes, n_nodes)
             Neighborhood matrix from nodes to nodes.
-        lower_neighborhood : torch.Tensor, shape = (-, -)
+        down_laplacian_1 : torch.Tensor, shape = (-, -)
             Lower Neighbourhood matrix.
-        upper_neighborhood : torch.Tensor, shape = (-, -)
+        up_laplacian_1 : torch.Tensor, shape = (-, -)
             Upper neighbourhood matrix.
 
         Returns
@@ -133,16 +140,19 @@ class CAN(torch.nn.Module):
         torch.Tensor, shape = (num_pooled_edges, heads * out_channels)
             Final hidden representations of pooled edges.
         """
+        adjacency_0 = adjacency_0.coalesce()
+        down_laplacian_1 = down_laplacian_1.coalesce()
+        up_laplacian_1 = up_laplacian_1.coalesce()
         if hasattr(self, "lift_layer"):
-            x_1 = self.lift_layer(x_0, neighborhood_0_to_0, x_1)
+            x_1 = self.lift_layer(x_0, adjacency_0.coalesce(), x_1)
 
         for layer in self.layers:
             if isinstance(layer, PoolLayer):
-                x_1, lower_neighborhood, upper_neighborhood = layer(
-                    x_1, lower_neighborhood, upper_neighborhood
+                x_1, down_laplacian_1, up_laplacian_1 = layer(
+                    x_1, down_laplacian_1, up_laplacian_1
                 )
             else:
-                x_1 = layer(x_1, lower_neighborhood, upper_neighborhood)
+                x_1 = layer(x_1, down_laplacian_1, up_laplacian_1)
                 x_1 = F.dropout(x_1, p=0.5, training=self.training)
 
         return x_1

--- a/topomodelx/nn/cell/ccxn.py
+++ b/topomodelx/nn/cell/ccxn.py
@@ -20,6 +20,8 @@ class CCXN(torch.nn.Module):
         Number of CCXN layers.
     att : bool
         Whether to use attention.
+    **kwargs : optional
+        Additional arguments CCXNLayer.
 
     References
     ----------
@@ -36,6 +38,7 @@ class CCXN(torch.nn.Module):
         in_channels_2,
         n_layers=2,
         att=False,
+        **kwargs,
     ):
         super().__init__()
 
@@ -45,11 +48,12 @@ class CCXN(torch.nn.Module):
                 in_channels_1=in_channels_1,
                 in_channels_2=in_channels_2,
                 att=att,
+                **kwargs,
             )
             for _ in range(n_layers)
         )
 
-    def forward(self, x_0, x_1, neighborhood_0_to_0, neighborhood_1_to_2):
+    def forward(self, x_0, x_1, adjacency_0, incidence_2_t):
         """Forward computation through layers.
 
         Parameters
@@ -58,9 +62,9 @@ class CCXN(torch.nn.Module):
             Input features on the nodes (0-cells).
         x_1 : torch.Tensor, shape = (n_edges, in_channels_1)
             Input features on the edges (1-cells).
-        neighborhood_0_to_0 : torch.Tensor, shape = (n_nodes, n_nodes)
+        adjacency_0 : torch.Tensor, shape = (n_nodes, n_nodes)
             Adjacency matrix of rank 0 (up).
-        neighborhood_1_to_2 : torch.Tensor, shape = (n_faces, n_edges)
+        incidence_2_t : torch.Tensor, shape = (n_faces, n_edges)
             Transpose of boundary matrix of rank 2.
 
         Returns
@@ -73,5 +77,5 @@ class CCXN(torch.nn.Module):
             Final hidden states of the faces (2-cells).
         """
         for layer in self.layers:
-            x_0, x_1, x_2 = layer(x_0, x_1, neighborhood_0_to_0, neighborhood_1_to_2)
+            x_0, x_1, x_2 = layer(x_0, x_1, adjacency_0, incidence_2_t)
         return (x_0, x_1, x_2)

--- a/topomodelx/nn/cell/ccxn_layer.py
+++ b/topomodelx/nn/cell/ccxn_layer.py
@@ -25,10 +25,8 @@ class CCXNLayer(torch.nn.Module):
         Dimension of input features on faces (2-cells).
     att : bool, default=False
         Whether to use attention.
-
-    Notes
-    -----
-    This is the architecture proposed for entire complex classification.
+    **kwargs : optional
+        Additional arguments for the modules of the CCXN layer.
 
     References
     ----------
@@ -45,7 +43,7 @@ class CCXNLayer(torch.nn.Module):
     """
 
     def __init__(
-        self, in_channels_0, in_channels_1, in_channels_2, att: bool = False
+        self, in_channels_0, in_channels_1, in_channels_2, att: bool = False, **kwargs
     ) -> None:
         super().__init__()
         self.conv_0_to_0 = Conv(
@@ -55,7 +53,7 @@ class CCXNLayer(torch.nn.Module):
             in_channels=in_channels_1, out_channels=in_channels_2, att=att
         )
 
-    def forward(self, x_0, x_1, neighborhood_0_to_0, neighborhood_1_to_2, x_2=None):
+    def forward(self, x_0, x_1, adjacency_0, incidence_2_t, x_2=None):
         r"""Forward pass.
 
         The forward pass was initially proposed in [1]_.
@@ -97,9 +95,9 @@ class CCXNLayer(torch.nn.Module):
             Input features on the nodes of the cell complex.
         x_1 : torch.Tensor, shape = (n_1_cells, channels)
             Input features on the edges of the cell complex.
-        neighborhood_0_to_0 : torch.sparse, shape = (n_0_cells, n_0_cells)
+        adjacency_0 : torch.sparse, shape = (n_0_cells, n_0_cells)
             Neighborhood matrix mapping nodes to nodes (A_0_up).
-        neighborhood_1_to_2 : torch.sparse, shape = (n_2_cells, n_1_cells)
+        incidence_2_t : torch.sparse, shape = (n_2_cells, n_1_cells)
             Neighborhood matrix mapping edges to faces (B_2^T).
         x_2 : torch.Tensor, shape = (n_2_cells, channels)
             Input features on the faces of the cell complex.
@@ -113,10 +111,10 @@ class CCXNLayer(torch.nn.Module):
         x_0 = torch.nn.functional.relu(x_0)
         x_1 = torch.nn.functional.relu(x_1)
 
-        x_0 = self.conv_0_to_0(x_0, neighborhood_0_to_0)
+        x_0 = self.conv_0_to_0(x_0, adjacency_0)
         x_0 = torch.nn.functional.relu(x_0)
 
-        x_2 = self.conv_1_to_2(x_1, neighborhood_1_to_2, x_2)
+        x_2 = self.conv_1_to_2(x_1, incidence_2_t, x_2)
         x_2 = torch.nn.functional.relu(x_2)
 
         return x_0, x_1, x_2

--- a/topomodelx/nn/cell/cwn.py
+++ b/topomodelx/nn/cell/cwn.py
@@ -21,6 +21,8 @@ class CWN(torch.nn.Module):
         Dimension of hidden features.
     n_layers : int
         Number of CWN layers.
+    **kwargs : optional
+        Additional arguments CWNLayer.
 
     References
     ----------
@@ -37,6 +39,7 @@ class CWN(torch.nn.Module):
         in_channels_2,
         hid_channels,
         n_layers,
+        **kwargs,
     ):
         super().__init__()
 
@@ -50,6 +53,7 @@ class CWN(torch.nn.Module):
                 in_channels_1=hid_channels,
                 in_channels_2=hid_channels,
                 out_channels=hid_channels,
+                **kwargs,
             )
             for _ in range(n_layers)
         )
@@ -59,9 +63,9 @@ class CWN(torch.nn.Module):
         x_0,
         x_1,
         x_2,
-        neighborhood_1_to_1,
-        neighborhood_2_to_1,
-        neighborhood_0_to_1,
+        adjacency_0,
+        incidence_2,
+        incidence_1_t,
     ):
         """Forward computation through projection, convolutions, linear layers and average pooling.
 
@@ -73,11 +77,11 @@ class CWN(torch.nn.Module):
             Input features on the edges (1-cells).
         x_2 : torch.Tensor, shape = (n_faces, in_channels_2)
             Input features on the faces (2-cells).
-        neighborhood_1_to_1 : torch.Tensor, shape = (n_edges, n_edges)
+        adjacency_0 : torch.Tensor, shape = (n_edges, n_edges)
             Upper-adjacency matrix of rank 1.
-        neighborhood_2_to_1 : torch.Tensor, shape = (n_edges, n_faces)
+        incidence_2 : torch.Tensor, shape = (n_edges, n_faces)
             Boundary matrix of rank 2.
-        neighborhood_0_to_1 : torch.Tensor, shape = (n_edges, n_nodes)
+        incidence_1_t : torch.Tensor, shape = (n_edges, n_nodes)
             Coboundary matrix of rank 1.
 
         Returns
@@ -98,9 +102,9 @@ class CWN(torch.nn.Module):
                 x_0,
                 x_1,
                 x_2,
-                neighborhood_1_to_1,
-                neighborhood_2_to_1,
-                neighborhood_0_to_1,
+                adjacency_0,
+                incidence_2,
+                incidence_1_t,
             )
 
         return x_0, x_1, x_2

--- a/tutorials/cell/can_train.ipynb
+++ b/tutorials/cell/can_train.ipynb
@@ -104,14 +104,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:06:36.009880829Z",
      "start_time": "2023-05-31T09:06:34.285257706Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<torch._C.Generator at 0x11d4905d0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import torch\n",
@@ -135,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:13:53.006542411Z",
@@ -175,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:13:55.279147916Z",
@@ -183,6 +194,15 @@
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading https://www.chrsmrrs.com/graphkerneldatasets/MUTAG.zip\n",
+      "Processing...\n",
+      "Done!\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -233,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:13:55.832585216Z",
@@ -242,8 +262,8 @@
    },
    "outputs": [],
    "source": [
-    "lower_neighborhood_list = []\n",
-    "upper_neighborhood_list = []\n",
+    "down_laplacian_list = []\n",
+    "up_laplacian_list = []\n",
     "adjacency_0_list = []\n",
     "\n",
     "for cell_complex in cc_list:\n",
@@ -251,20 +271,20 @@
     "    adjacency_0 = torch.from_numpy(adjacency_0.todense()).to_sparse()\n",
     "    adjacency_0_list.append(adjacency_0)\n",
     "\n",
-    "    lower_neighborhood_t = cell_complex.down_laplacian_matrix(rank=1)\n",
-    "    lower_neighborhood_t = from_sparse(lower_neighborhood_t)\n",
-    "    lower_neighborhood_list.append(lower_neighborhood_t)\n",
+    "    down_laplacian_t = cell_complex.down_laplacian_matrix(rank=1)\n",
+    "    down_laplacian_t = from_sparse(down_laplacian_t)\n",
+    "    down_laplacian_list.append(down_laplacian_t)\n",
     "\n",
     "    try:\n",
-    "        upper_neighborhood_t = cell_complex.up_laplacian_matrix(rank=1)\n",
-    "        upper_neighborhood_t = from_sparse(upper_neighborhood_t)\n",
+    "        up_laplacian_t = cell_complex.up_laplacian_matrix(rank=1)\n",
+    "        up_laplacian_t = from_sparse(up_laplacian_t)\n",
     "    except ValueError:\n",
-    "        upper_neighborhood_t = np.zeros(\n",
-    "            (lower_neighborhood_t.shape[0], lower_neighborhood_t.shape[0])\n",
+    "        up_laplacian_t = np.zeros(\n",
+    "            (down_laplacian_t.shape[0], down_laplacian_t.shape[0])\n",
     "        )\n",
-    "        upper_neighborhood_t = torch.from_numpy(upper_neighborhood_t).to_sparse()\n",
+    "        up_laplacian_t = torch.from_numpy(up_laplacian_t).to_sparse()\n",
     "\n",
-    "    upper_neighborhood_list.append(upper_neighborhood_t)"
+    "    up_laplacian_list.append(up_laplacian_t)"
    ]
   },
   {
@@ -278,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,8 +327,8 @@
     "        self.lin_0 = torch.nn.Linear(heads * out_channels, 128)\n",
     "        self.lin_1 = torch.nn.Linear(128, num_classes)\n",
     "\n",
-    "    def forward(self, x_0, x_1, adjacency, lower_neighborhood, upper_neighborhood):\n",
-    "        x = self.base_model(x_0, x_1, adjacency, lower_neighborhood, upper_neighborhood)\n",
+    "    def forward(self, x_0, x_1, adjacency, down_laplacian, up_laplacian):\n",
+    "        x = self.base_model(x_0, x_1, adjacency, down_laplacian, up_laplacian)\n",
     "        # max pooling over edges in each graph\n",
     "        x = x.max(dim=0)[0]\n",
     "        # Feed-Foward Neural Network to predict the graph label\n",
@@ -318,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:13:56.672913561Z",
@@ -358,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:19:40.411845803Z",
@@ -399,9 +419,6 @@
        "        (lin): Linear(in_features=64, out_features=64, bias=False)\n",
        "        (aggregation): Aggregation()\n",
        "      )\n",
-       "      (2): PoolLayer(\n",
-       "        (signal_pool_activation): Sigmoid()\n",
-       "      )\n",
        "    )\n",
        "  )\n",
        "  (lin_0): Linear(in_features=64, out_features=128, bias=True)\n",
@@ -409,7 +426,7 @@
        ")"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -429,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:19:41.150933630Z",
@@ -441,11 +458,11 @@
     "test_size = 0.3\n",
     "x_1_train, x_1_test = train_test_split(x_1_list, test_size=test_size, shuffle=False)\n",
     "x_0_train, x_0_test = train_test_split(x_0_list, test_size=test_size, shuffle=False)\n",
-    "lower_neighborhood_train, lower_neighborhood_test = train_test_split(\n",
-    "    lower_neighborhood_list, test_size=test_size, shuffle=False\n",
+    "down_laplacian_train, down_laplacian_test = train_test_split(\n",
+    "    down_laplacian_list, test_size=test_size, shuffle=False\n",
     ")\n",
-    "upper_neighborhood_train, upper_neighborhood_test = train_test_split(\n",
-    "    upper_neighborhood_list, test_size=test_size, shuffle=False\n",
+    "up_laplacian_train, up_laplacian_test = train_test_split(\n",
+    "    up_laplacian_list, test_size=test_size, shuffle=False\n",
     ")\n",
     "adjacency_0_train, adjacency_0_test = train_test_split(\n",
     "    adjacency_0_list, test_size=test_size, shuffle=False\n",
@@ -462,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-05-31T09:19:42.918836083Z",
@@ -474,26 +491,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch: 1 loss: 0.6200 Train_acc: 0.6947\n",
+      "Epoch: 1 loss: 0.6159 Train_acc: 0.6947\n",
       "Test_acc: 0.5965\n",
-      "Epoch: 2 loss: 0.6110 Train_acc: 0.6947\n",
+      "Epoch: 2 loss: 0.6099 Train_acc: 0.6947\n",
       "Test_acc: 0.5965\n",
-      "Epoch: 3 loss: 0.6054 Train_acc: 0.6947\n",
+      "Epoch: 3 loss: 0.6035 Train_acc: 0.6947\n",
       "Test_acc: 0.5965\n",
-      "Epoch: 4 loss: 0.5990 Train_acc: 0.6947\n",
+      "Epoch: 4 loss: 0.5966 Train_acc: 0.7176\n",
       "Test_acc: 0.6316\n",
-      "Epoch: 5 loss: 0.6021 Train_acc: 0.7099\n",
-      "Test_acc: 0.6316\n",
-      "Epoch: 6 loss: 0.5911 Train_acc: 0.7252\n",
-      "Test_acc: 0.6316\n",
-      "Epoch: 7 loss: 0.5889 Train_acc: 0.7176\n",
-      "Test_acc: 0.6316\n",
-      "Epoch: 8 loss: 0.5829 Train_acc: 0.7252\n",
-      "Test_acc: 0.6842\n",
-      "Epoch: 9 loss: 0.5786 Train_acc: 0.7252\n",
+      "Epoch: 5 loss: 0.5909 Train_acc: 0.7252\n",
       "Test_acc: 0.6491\n",
-      "Epoch: 10 loss: 0.5746 Train_acc: 0.7328\n",
-      "Test_acc: 0.6842\n"
+      "Epoch: 6 loss: 0.5983 Train_acc: 0.7099\n",
+      "Test_acc: 0.6316\n",
+      "Epoch: 7 loss: 0.5884 Train_acc: 0.7252\n",
+      "Test_acc: 0.6491\n",
+      "Epoch: 8 loss: 0.5909 Train_acc: 0.7176\n",
+      "Test_acc: 0.6316\n",
+      "Epoch: 9 loss: 0.5818 Train_acc: 0.7252\n",
+      "Test_acc: 0.6316\n",
+      "Epoch: 10 loss: 0.5879 Train_acc: 0.7252\n",
+      "Test_acc: 0.6316\n"
      ]
     }
    ],
@@ -505,24 +522,24 @@
     "    num_samples = 0\n",
     "    correct = 0\n",
     "    model.train()\n",
-    "    for x_0, x_1, adjacency, lower_neighborhood, upper_neighborhood, y in zip(\n",
+    "    for x_0, x_1, adjacency, down_laplacian, up_laplacian, y in zip(\n",
     "        x_0_train,\n",
     "        x_1_train,\n",
     "        adjacency_0_train,\n",
-    "        lower_neighborhood_train,\n",
-    "        upper_neighborhood_train,\n",
+    "        down_laplacian_train,\n",
+    "        up_laplacian_train,\n",
     "        y_train,\n",
     "        strict=True,\n",
     "    ):\n",
     "        x_0 = x_0.float().to(device)\n",
     "        x_1, y = x_1.float().to(device), torch.tensor(y, dtype=torch.long).to(device)\n",
     "        adjacency = adjacency.float().to(device)\n",
-    "        lower_neighborhood, upper_neighborhood = (\n",
-    "            lower_neighborhood.float().to(device),\n",
-    "            upper_neighborhood.float().to(device),\n",
+    "        down_laplacian, up_laplacian = (\n",
+    "            down_laplacian.float().to(device),\n",
+    "            up_laplacian.float().to(device),\n",
     "        )\n",
     "        opt.zero_grad()\n",
-    "        y_hat = model(x_0, x_1, adjacency, lower_neighborhood, upper_neighborhood)\n",
+    "        y_hat = model(x_0, x_1, adjacency, down_laplacian, up_laplacian)\n",
     "        loss = crit(y_hat, y)\n",
     "        correct += (y_hat.argmax() == y).sum().item()\n",
     "        num_samples += 1\n",
@@ -538,12 +555,12 @@
     "        with torch.no_grad():\n",
     "            num_samples = 0\n",
     "            correct = 0\n",
-    "            for x_0, x_1, adjacency, lower_neighborhood, upper_neighborhood, y in zip(\n",
+    "            for x_0, x_1, adjacency, down_laplacian, up_laplacian, y in zip(\n",
     "                x_0_test,\n",
     "                x_1_test,\n",
     "                adjacency_0_test,\n",
-    "                lower_neighborhood_test,\n",
-    "                upper_neighborhood_test,\n",
+    "                down_laplacian_test,\n",
+    "                up_laplacian_test,\n",
     "                y_test,\n",
     "                strict=True,\n",
     "            ):\n",
@@ -553,13 +570,11 @@
     "                    torch.tensor(y, dtype=torch.long).to(device),\n",
     "                )\n",
     "                adjacency = adjacency.float().to(device)\n",
-    "                lower_neighborhood, upper_neighborhood = (\n",
-    "                    lower_neighborhood.float().to(device),\n",
-    "                    upper_neighborhood.float().to(device),\n",
+    "                down_laplacian, up_laplacian = (\n",
+    "                    down_laplacian.float().to(device),\n",
+    "                    up_laplacian.float().to(device),\n",
     "                )\n",
-    "                y_hat = model(\n",
-    "                    x_0, x_1, adjacency, lower_neighborhood, upper_neighborhood\n",
-    "                )\n",
+    "                y_hat = model(x_0, x_1, adjacency, down_laplacian, up_laplacian)\n",
     "                correct += (y_hat.argmax() == y).sum().item()\n",
     "                num_samples += 1\n",
     "            test_acc = correct / num_samples\n",
@@ -576,9 +591,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv_modelx",
+   "display_name": "venv_tmx",
    "language": "python",
-   "name": "venv_modelx"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -591,11 +606,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.3"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "97e7f600578393f7b22fad5e1bb04e54aa849deabd28651fd7e27af1b0c8a034"
-   }
   }
  },
  "nbformat": 4,

--- a/tutorials/cell/ccxn_train.ipynb
+++ b/tutorials/cell/ccxn_train.ipynb
@@ -269,10 +269,8 @@
     "        self.lin_1 = torch.nn.Linear(in_channels_1, num_classes)\n",
     "        self.lin_2 = torch.nn.Linear(in_channels_2, num_classes)\n",
     "\n",
-    "    def forward(self, x_0, x_1, neighborhood_0_to_0, neighborhood_1_to_2):\n",
-    "        x_0, x_1, x_2 = self.base_model(\n",
-    "            x_0, x_1, neighborhood_0_to_0, neighborhood_1_to_2\n",
-    "        )\n",
+    "    def forward(self, x_0, x_1, adjacency_0, incidence_2_t):\n",
+    "        x_0, x_1, x_2 = self.base_model(x_0, x_1, adjacency_0, incidence_2_t)\n",
     "        x_0 = self.lin_0(x_0)\n",
     "        x_1 = self.lin_1(x_1)\n",
     "        x_2 = self.lin_2(x_2)\n",
@@ -436,7 +434,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/gbg141/Documents/TopoProjectX/TopoModelX/venv_modelx/lib/python3.11/site-packages/torch/nn/modules/loss.py:536: UserWarning: Using a target size (torch.Size([])) that is different to the input size (torch.Size([2])). This will likely lead to incorrect results due to broadcasting. Please ensure they have the same size.\n",
+      "/Users/gbg141/Documents/Projects/TopoModelX/venv_tmx/lib/python3.11/site-packages/torch/nn/modules/loss.py:536: UserWarning: Using a target size (torch.Size([])) that is different to the input size (torch.Size([2])). This will likely lead to incorrect results due to broadcasting. Please ensure they have the same size.\n",
       "  return F.mse_loss(input, target, reduction=self.reduction)\n"
      ]
     },

--- a/tutorials/cell/cwn_train.ipynb
+++ b/tutorials/cell/cwn_train.ipynb
@@ -52,7 +52,18 @@
     },
     "id": "h-kcMSPGNH1v"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<torch._C.Generator at 0x16d07b750>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import toponetx.datasets as datasets\n",
@@ -318,12 +329,12 @@
     "        x_0,\n",
     "        x_1,\n",
     "        x_2,\n",
-    "        neighborhood_1_to_1,\n",
-    "        neighborhood_2_to_1,\n",
-    "        neighborhood_0_to_1,\n",
+    "        adjacency_1,\n",
+    "        incidence_2,\n",
+    "        incidence_1_t,\n",
     "    ):\n",
     "        x_0, x_1, x_2 = self.base_model(\n",
-    "            x_0, x_1, x_2, neighborhood_1_to_1, neighborhood_2_to_1, neighborhood_0_to_1\n",
+    "            x_0, x_1, x_2, adjacency_1, incidence_2, incidence_1_t\n",
     "        )\n",
     "        x_0 = self.lin_0(x_0)\n",
     "        x_1 = self.lin_1(x_1)\n",
@@ -492,13 +503,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch:2, Train Loss: 83.8053 Test Loss: 73.7517\n"
+      "Epoch:2, Train Loss: 83.8053 Test Loss: 73.7517\n",
+      "Epoch:4, Train Loss: 81.9551 Test Loss: 50.2781\n",
+      "Epoch:6, Train Loss: 78.3991 Test Loss: 49.9035\n",
+      "Epoch:8, Train Loss: 75.8110 Test Loss: 45.7197\n",
+      "Epoch:10, Train Loss: 74.3838 Test Loss: 40.5566\n"
      ]
     }
    ],
    "source": [
     "test_interval = 2\n",
-    "num_epochs = 2\n",
+    "num_epochs = 10\n",
     "\n",
     "for epoch_i in range(1, num_epochs + 1):\n",
     "    epoch_loss = []\n",
@@ -577,9 +592,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "venv_modelx",
+   "display_name": "venv_tmx",
    "language": "python",
-   "name": "venv_modelx"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -592,11 +607,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.3"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request aims to update the input logic of cell complex models by
- unifying the nomenclature of connectivity matrices across the different models, in accordance to TopoNetX library (i.e. `adjacency_r`, `incidence_r`, `down_laplacian_r`, etc.);
- adding `**kwargs` optional parameter to models and layers, hence allowing the flexibility to modify additional parameters of the model's inner layers (standard practice in other libraries such as `torch_geometric`).

Upon acceptance of these changes, similar modifications will be applied to Hypergraph, Simplicial, and Combinatorial models.