### PR TITLE
Update the Input Logic of Hypergraph Models

### DIFF
--- a/topomodelx/nn/hypergraph/allset.py
+++ b/topomodelx/nn/hypergraph/allset.py
@@ -16,18 +16,20 @@ class AllSet(torch.nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    n_layers : int, default: 2
+    n_layers : int, default = 2
         Number of AllSet layers in the network.
-    layer_dropout: float, default: 0.2
+    layer_dropout : float, default = 0.2
         Dropout probability for the AllSet layer.
-    mlp_num_layers : int, default: 2
+    mlp_num_layers : int, default = 2
         Number of layers in the MLP.
-    mlp_dropout : float, default: 0.0
-        Dropout probability for the MLP.
-    mlp_activation : torch.nn.Module, default: None
+    mlp_activation : torch.nn.Module, default = None
         Activation function in the MLP.
-    mlp_norm : bool, default: False
+    mlp_dropout : float, default = 0.0
+        Dropout probability for the MLP.
+    mlp_norm : bool, default = False
         Whether to apply input normalization in the MLP.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -47,6 +49,7 @@ class AllSet(torch.nn.Module):
         mlp_activation=None,
         mlp_dropout=0.0,
         mlp_norm=None,
+        **kwargs,
     ):
         super().__init__()
 
@@ -59,6 +62,7 @@ class AllSet(torch.nn.Module):
                 mlp_activation=mlp_activation,
                 mlp_dropout=mlp_dropout,
                 mlp_norm=mlp_norm,
+                **kwargs,
             )
             for i in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/allset_transformer.py
+++ b/topomodelx/nn/hypergraph/allset_transformer.py
@@ -26,6 +26,8 @@ class AllSetTransformer(torch.nn.Module):
         Number of layers in the MLP.
     mlp_dropout : float, default: 0.2
         Dropout probability in the MLP.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -44,6 +46,7 @@ class AllSetTransformer(torch.nn.Module):
         dropout=0.2,
         mlp_num_layers=2,
         mlp_dropout=0.2,
+        **kwargs,
     ):
         super().__init__()
 
@@ -55,6 +58,7 @@ class AllSetTransformer(torch.nn.Module):
                 heads=heads,
                 mlp_num_layers=mlp_num_layers,
                 mlp_dropout=mlp_dropout,
+                **kwargs,
             )
             for i in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/allset_transformer_layer.py
+++ b/topomodelx/nn/hypergraph/allset_transformer_layer.py
@@ -32,6 +32,8 @@ class AllSetTransformerLayer(nn.Module):
         Dropout probability in the MLP.
     mlp_norm : str or None, optional
         Type of layer normalization in the MLP.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -52,6 +54,7 @@ class AllSetTransformerLayer(nn.Module):
         mlp_activation=nn.ReLU,
         mlp_dropout: float = 0.0,
         mlp_norm=None,
+        **kwargs,
     ) -> None:
         super().__init__()
 

--- a/topomodelx/nn/hypergraph/dhgcn.py
+++ b/topomodelx/nn/hypergraph/dhgcn.py
@@ -16,8 +16,10 @@ class DHGCN(torch.nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    n_layer : int, default = 2
+    n_layers : int, default = 2
         Amount of message passing layers.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -31,6 +33,7 @@ class DHGCN(torch.nn.Module):
         in_channels,
         hidden_channels,
         n_layers=1,
+        **kwargs,
     ):
         super().__init__()
 
@@ -39,6 +42,7 @@ class DHGCN(torch.nn.Module):
                 in_channels=in_channels if i == 0 else hidden_channels,
                 intermediate_channels=hidden_channels,
                 out_channels=hidden_channels,
+                **kwargs,
             )
             for i in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/dhgcn_layer.py
+++ b/topomodelx/nn/hypergraph/dhgcn_layer.py
@@ -18,6 +18,14 @@ class DHGCNLayer(torch.nn.Module):
         Dimension of intermediate features.
     out_channels : int
         Dimension of output features.
+    k_neighbours : int, default=3
+        Number of neighbours to consider in the local topology.
+    k_centroids : int, default=4
+        Number of centroids to consider in the global topology.
+    device : str, default="cpu"
+        Device to store the tensors.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -40,6 +48,7 @@ class DHGCNLayer(torch.nn.Module):
         k_neighbours: int = 3,
         k_centroids: int = 4,
         device: str = "cpu",
+        **kwargs,
     ) -> None:
         super().__init__()
 
@@ -69,7 +78,7 @@ class DHGCNLayer(torch.nn.Module):
         x : torch.Tensor, shape = (n_nodes, node_features)
             Input features on the nodes of the simplicial complex.
         k : int
-            Number of clusters/centroids
+            Number of clusters/centroids.
         flow : str
             If this parameter has value "source_to_target", the output will have the shape
             [n_nodes, n_hyperedges = k_centroids].
@@ -80,11 +89,9 @@ class DHGCNLayer(torch.nn.Module):
 
         Returns
         -------
-        hyperedge_index : torch.Tensor, shape = (n_nodes, 2)
-            Indices of the on-zero values in the feature matrix of hypergraph
-            convolutional network.
-            The order of dimensions of the matrix is defined by the value of the flow
-            parameter.
+        torch.Tensor
+            Indices of the on-zero values in the feature matrix of hypergraph convolutional network.
+            The order of dimensions of the matrix is defined by the value of the flow parameter.
         """
         assert flow in ["source_to_target", "target_to_source"]
         device = x.device
@@ -142,10 +149,12 @@ class DHGCNLayer(torch.nn.Module):
         ----------
         x_0 : torch.Tensor, shape = (n_nodes, node_features)
             Input features on the nodes of the simplicial complex.
+        k : int
+            Number of clusters/centroids.
 
         Returns
         -------
-        hyperedge_index : torch.Tensor, shape = (n_nodes, 2)
+        torch.Tensor
             Indices of the on-zero values in the feature matrix of hypergraph convolutional network.
         """
         if k is None:
@@ -166,8 +175,8 @@ class DHGCNLayer(torch.nn.Module):
 
         Returns
         -------
-        hyperedge_incidence_matrix : torch.Tensor, shape = (n_nodes, n_nodes + k_centroids)
-            Incidence matrix mapping edges to nodes.
+        torch.Tensor
+            Incidence matrix mapping edges to nodes, shape = (n_nodes, n_nodes + k_centroids).
         """
         device = x_0_features.device
         n_nodes = x_0_features.size(0)

--- a/topomodelx/nn/hypergraph/hmpnn.py
+++ b/topomodelx/nn/hypergraph/hmpnn.py
@@ -12,18 +12,18 @@ class HMPNN(torch.nn.Module):
     Parameters
     ----------
     in_channels : int
-        Dimension of input features
+        Dimension of input features.
     hidden_channels : Tuple[int]
         A tuple of hidden feature dimensions to gradually reduce node/hyperedge representations feature
         dimension from in_features to the last item in the tuple.
-    num_classes: int
-        Number of classes
     n_layers : int, default = 2
         Number of HMPNNLayer layers.
-    adjacency_dropout_rate: int, default = 0.7
+    adjacency_dropout_rate : int, default = 0.7
         Adjacency dropout rate.
     regular_dropout_rate : int, default = 0.5
         Regular dropout rate applied on features.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -40,6 +40,7 @@ class HMPNN(torch.nn.Module):
         n_layers=2,
         adjacency_dropout_rate=0.7,
         regular_dropout_rate=0.5,
+        **kwargs,
     ):
         super().__init__()
 
@@ -52,6 +53,7 @@ class HMPNN(torch.nn.Module):
                     hidden_channels,
                     adjacency_dropout=adjacency_dropout_rate,
                     updating_dropout=regular_dropout_rate,
+                    **kwargs,
                 )
                 for _ in range(n_layers)
             ]
@@ -66,7 +68,7 @@ class HMPNN(torch.nn.Module):
             Node features.
         x_1 : torch.Tensor, shape = (n_hyperedges, in_features)
             Hyperedge features.
-        incidence_1: torch.sparse.Tensor, shape = (n_nodes, n_hyperedges)
+        incidence_1 : torch.sparse.Tensor, shape = (n_nodes, n_hyperedges)
             Incidence matrix (B1).
 
         Returns

--- a/topomodelx/nn/hypergraph/hnhn.py
+++ b/topomodelx/nn/hypergraph/hnhn.py
@@ -20,6 +20,8 @@ class HNHN(torch.nn.Module):
         Number of HNHN message passing layers.
     layer_drop : float, default = 0.2
         Dropout rate for the hidden features.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -30,7 +32,13 @@ class HNHN(torch.nn.Module):
     """
 
     def __init__(
-        self, in_channels, hidden_channels, incidence_1, n_layers=2, layer_drop=0.2
+        self,
+        in_channels,
+        hidden_channels,
+        incidence_1,
+        n_layers=2,
+        layer_drop=0.2,
+        **kwargs,
     ):
         super().__init__()
 
@@ -39,6 +47,7 @@ class HNHN(torch.nn.Module):
                 in_channels=in_channels if i == 0 else hidden_channels,
                 hidden_channels=hidden_channels,
                 incidence_1=incidence_1,
+                **kwargs,
             )
             for i in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/hnhn_layer.py
+++ b/topomodelx/nn/hypergraph/hnhn_layer.py
@@ -39,6 +39,8 @@ class HNHNLayer(torch.nn.Module):
         Gain for the bias initialization.
     bias_init : Literal["xavier_uniform", "xavier_normal"], default="xavier_uniform"
         Controls the bias initialization method.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     Notes
     -----
@@ -69,6 +71,7 @@ class HNHNLayer(torch.nn.Module):
         beta: float = -0.5,
         bias_gain: float = 1.414,
         bias_init: Literal["xavier_uniform", "xavier_normal"] = "xavier_uniform",
+        **kwargs,
     ) -> None:
         super().__init__()
         self.use_bias = use_bias
@@ -184,7 +187,7 @@ class HNHNLayer(torch.nn.Module):
         ----------
         x_0 : torch.Tensor, shape = (n_nodes, channels_node)
             Input features on the hypernodes.
-        incidence_1: torch.Tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Incidence matrix mapping edges to nodes (B_1).
 
         Returns

--- a/topomodelx/nn/hypergraph/hypergat.py
+++ b/topomodelx/nn/hypergraph/hypergat.py
@@ -16,8 +16,10 @@ class HyperGAT(torch.nn.Module):
         Dimension of the hidden features.
     n_layers : int, default = 2
         Amount of message passing layers.
-    layer_drop: float, default = 0.2
+    layer_drop : float, default = 0.2
         Dropout rate for the hidden features.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -32,6 +34,7 @@ class HyperGAT(torch.nn.Module):
         hidden_channels,
         n_layers=2,
         layer_drop=0.2,
+        **kwargs,
     ):
         super().__init__()
 
@@ -39,6 +42,7 @@ class HyperGAT(torch.nn.Module):
             HyperGATLayer(
                 in_channels=in_channels if i == 0 else hidden_channels,
                 hidden_channels=hidden_channels,
+                **kwargs,
             )
             for i in range(n_layers)
         )
@@ -49,8 +53,8 @@ class HyperGAT(torch.nn.Module):
 
         Parameters
         ----------
-        x_1 : torch.Tensor, shape = (n_edges, channels_edge)
-            Edge features.
+        x_0 : torch.Tensor, shape = (n_nodes, channels_nodes)
+            Node features.
         incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 

--- a/topomodelx/nn/hypergraph/hypersage.py
+++ b/topomodelx/nn/hypergraph/hypersage.py
@@ -14,10 +14,12 @@ class HyperSAGE(torch.nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    n_layer : int, default = 2
+    n_layers : int, default = 2
         Amount of message passing layers.
     alpha : int, default = -1
-        Max number of nodes in a neighborhood to consider. If -1 it considers all the nodes.ù
+        Max number of nodes in a neighborhood to consider. If -1 it considers all the nodes.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -39,14 +41,14 @@ class HyperSAGE(torch.nn.Module):
             for i in range(n_layers)
         )
 
-    def forward(self, x_0, incidence):
+    def forward(self, x_0, incidence_1):
         """Forward computation through layers, then linear layer, then global max pooling.
 
         Parameters
         ----------
-        x : torch.Tensor, shape = (n_nodes, features_nodes)
+        x_0 : torch.Tensor, shape = (n_nodes, features_nodes)
             Edge features.
-        incidence : torch.Tensor, shape = (n_nodes, n_edges)
+        incidence_1 : torch.Tensor, shape = (n_nodes, n_edges)
             Boundary matrix of rank 1.
 
         Returns
@@ -55,6 +57,6 @@ class HyperSAGE(torch.nn.Module):
             Label assigned to whole complex.
         """
         for layer in self.layers:
-            x_0 = layer.forward(x_0, incidence)
+            x_0 = layer.forward(x_0, incidence_1)
 
         return x_0

--- a/topomodelx/nn/hypergraph/hypersage_layer.py
+++ b/topomodelx/nn/hypergraph/hypersage_layer.py
@@ -61,6 +61,8 @@ class HyperSAGELayer(MessagePassing):
         Initialization method.
     device : str, default="cpu"
         Device name to train layer on.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -87,6 +89,7 @@ class HyperSAGELayer(MessagePassing):
             "uniform", "xavier_uniform", "xavier_normal"
         ] = "uniform",
         device: str = "cpu",
+        **kwargs,
     ) -> None:
         super().__init__(
             initialization=initialization,
@@ -191,6 +194,18 @@ class HyperSAGELayer(MessagePassing):
         """
 
         def nodes_per_edge(e):
+            r"""Get nodes per edge.
+
+            Parameters
+            ----------
+            e : int
+                Edge index.
+
+            Returns
+            -------
+            torch.Tensor
+                Nodes per edge.
+            """
             messages = (
                 torch.index_select(
                     input=incidence.to("cpu"), dim=1, index=torch.LongTensor([e])
@@ -204,6 +219,18 @@ class HyperSAGELayer(MessagePassing):
             return messages[torch.randperm(len(messages))[: self.alpha]]
 
         def edges_per_node(v):
+            r"""Get edges per node.
+
+            Parameters
+            ----------
+            v : int
+                Node index.
+
+            Returns
+            -------
+            torch.Tensor
+                Edges per node.
+            """
             return (
                 torch.index_select(
                     input=incidence.to("cpu"), dim=0, index=torch.LongTensor([v])

--- a/topomodelx/nn/hypergraph/unigcn.py
+++ b/topomodelx/nn/hypergraph/unigcn.py
@@ -16,6 +16,8 @@ class UniGCN(torch.nn.Module):
         Dimension of the hidden features.
     n_layers : int, default = 2
         Amount of message passing layers.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -30,6 +32,7 @@ class UniGCN(torch.nn.Module):
         in_channels,
         hidden_channels,
         n_layers=2,
+        **kwargs,
     ):
         super().__init__()
 
@@ -37,6 +40,7 @@ class UniGCN(torch.nn.Module):
             UniGCNLayer(
                 in_channels=in_channels if i == 0 else hidden_channels,
                 hidden_channels=hidden_channels,
+                **kwargs,
             )
             for i in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/unigcn_layer.py
+++ b/topomodelx/nn/hypergraph/unigcn_layer.py
@@ -16,10 +16,12 @@ class UniGCNLayer(torch.nn.Module):
         Dimension of the input features.
     hidden_channels : int
         Dimension of the hidden features.
-    use_bn : bool, default=False
-        Whether to use bathnorm after the linear transformation.
     aggr_norm : bool, default=False
         Whether to normalize the aggregated message by the neighborhood size.
+    use_bn : bool, default=False
+        Whether to use bathnorm after the linear transformation.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -41,6 +43,7 @@ class UniGCNLayer(torch.nn.Module):
         hidden_channels,
         aggr_norm: bool = False,
         use_bn: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__()
 

--- a/topomodelx/nn/hypergraph/unigcnii.py
+++ b/topomodelx/nn/hypergraph/unigcnii.py
@@ -28,6 +28,8 @@ class UniGCNII(torch.nn.Module):
         Dropout rate for the hidden features.
     use_norm : bool, default=False
         Whether to apply row normalization after every layer.
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -47,6 +49,7 @@ class UniGCNII(torch.nn.Module):
         input_drop=0.2,
         layer_drop=0.2,
         use_norm=False,
+        **kwargs,
     ):
         super().__init__()
         layers = []
@@ -65,6 +68,7 @@ class UniGCNII(torch.nn.Module):
                     alpha=alpha,
                     beta=beta,
                     use_norm=use_norm,
+                    **kwargs,
                 )
             )
 

--- a/topomodelx/nn/hypergraph/unigcnii_layer.py
+++ b/topomodelx/nn/hypergraph/unigcnii_layer.py
@@ -20,6 +20,8 @@ class UniGCNIILayer(torch.nn.Module):
         The beta parameter determining the importance of the learned matrix (\theta_1).
     use_norm : bool, default=False
         Whether to apply row normalization after the layer.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -30,7 +32,13 @@ class UniGCNIILayer(torch.nn.Module):
     """
 
     def __init__(
-        self, in_channels, hidden_channels, alpha: float, beta: float, use_norm=False
+        self,
+        in_channels,
+        hidden_channels,
+        alpha: float,
+        beta: float,
+        use_norm=False,
+        **kwargs,
     ) -> None:
         super().__init__()
 
@@ -86,7 +94,7 @@ class UniGCNIILayer(torch.nn.Module):
         incidence_1 : torch.Tensor, shape = (num_nodes, num_edges)
             Incidence matrix of the hypergraph.
             It is expected that the incidence matrix contains self-loops for all nodes.
-        x_skip : torch.Tensor, shape = (num_nodes, in_channels), optional
+        x_skip : torch.Tensor, shape = (num_nodes, in_channels)
             Original node features of the hypergraph used for the skip connections.
             If not provided, the input to the layer is used as a skip connection.
 
@@ -96,7 +104,6 @@ class UniGCNIILayer(torch.nn.Module):
             Output node features.
         x_1 : torch.Tensor
             Output hyperedge features.
-
         """
         x_skip = x_0 if x_skip is None else x_skip
         incidence_1_transpose = incidence_1.transpose(0, 1)

--- a/topomodelx/nn/hypergraph/unigin.py
+++ b/topomodelx/nn/hypergraph/unigin.py
@@ -26,7 +26,8 @@ class UniGIN(torch.nn.Module):
         Whether to make eps a trainable parameter.
     use_norm : bool, default=False
         Whether to apply row normalization after every layer.
-
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -46,6 +47,7 @@ class UniGIN(torch.nn.Module):
         eps=0,
         train_eps=False,
         use_norm=False,
+        **kwargs,
     ):
         super().__init__()
 
@@ -60,6 +62,7 @@ class UniGIN(torch.nn.Module):
                 eps=eps,
                 train_eps=train_eps,
                 use_norm=use_norm,
+                **kwargs,
             )
             for _ in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/unigin_layer.py
+++ b/topomodelx/nn/hypergraph/unigin_layer.py
@@ -19,7 +19,8 @@ class UniGINLayer(torch.nn.Module):
         Whether to make eps a trainable parameter.
     use_norm : bool, default=False
         Whether to apply row normalization after the layer.
-
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -41,6 +42,7 @@ class UniGINLayer(torch.nn.Module):
         eps: float = 0.0,
         train_eps: bool = False,
         use_norm: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__()
 

--- a/topomodelx/nn/hypergraph/unisage.py
+++ b/topomodelx/nn/hypergraph/unisage.py
@@ -26,9 +26,10 @@ class UniSAGE(torch.nn.Module):
         Aggregator function for hyperedges.
     v_aggr : Literal["sum", "mean",], default="mean"
         Aggregator function for nodes.
-    use_norm : boolean
+    use_norm : bool
         Whether to apply row normalization after every layer.
-
+    **kwargs : optional
+        Additional arguments for the inner layers.
 
     References
     ----------
@@ -54,6 +55,7 @@ class UniSAGE(torch.nn.Module):
             "mean",
         ] = "mean",
         use_norm: bool = False,
+        **kwargs,
     ):
         super().__init__()
 
@@ -67,6 +69,7 @@ class UniSAGE(torch.nn.Module):
                 e_aggr=e_aggr,
                 v_aggr=v_aggr,
                 use_norm=use_norm,
+                **kwargs,
             )
             for i in range(n_layers)
         )

--- a/topomodelx/nn/hypergraph/unisage_layer.py
+++ b/topomodelx/nn/hypergraph/unisage_layer.py
@@ -20,8 +20,10 @@ class UniSAGELayer(torch.nn.Module):
         Aggregator function for hyperedges.
     v_aggr : Literal["sum", "mean",], default="mean"
         Aggregator function for nodes.
-    use_norm : boolean
+    use_norm : bool
         Whether to apply row normalization after every layer.
+    **kwargs : optional
+        Additional arguments for the layer modules.
 
     References
     ----------
@@ -38,6 +40,13 @@ class UniSAGELayer(torch.nn.Module):
     """
 
     def _validate_aggr(self, aggr):
+        r"""Validate aggregator.
+
+        Parameters
+        ----------
+        aggr : str
+            Aggregator function.
+        """
         if aggr not in {
             "sum",
             "mean",
@@ -59,6 +68,7 @@ class UniSAGELayer(torch.nn.Module):
             "mean",
         ] = "mean",
         use_norm: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels


### PR DESCRIPTION
Following PR #273 , this pull request checks the input nomenclature among hypergraph models and adds the `**kwargs` optional parameter to both models and layers. Additionally, bits of documentation have been added and/or modified to pass the new `numpydoc_validation` tests.