### PR TITLE
efficient implementation of attention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3.11
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/topomodelx/nn/hypergraph/allset_transformer_layer.py
+++ b/topomodelx/nn/hypergraph/allset_transformer_layer.py
@@ -375,9 +375,7 @@ class MultiHeadAttention(MessagePassing):
         x_K = torch.matmul(x_source, self.K_weight).permute(1, 0, 2)
         alpha = (x_K * self.Q_weight.permute(1, 0, 2)).sum(-1)
         alpha = F.leaky_relu(alpha, 0.2)
-        alpha_soft = softmax(alpha[self.source_index_j], index=self.target_index_i)
-
-        return alpha_soft
+        return softmax(alpha[self.source_index_j], index=self.target_index_i)
 
     def forward(self, x_source, neighborhood):
         """Forward pass.
@@ -409,10 +407,7 @@ class MultiHeadAttention(MessagePassing):
         x_message = x_message.permute(1, 0, 2)[
             self.source_index_j
         ] * attention_values.unsqueeze(-1)
-        x_message = scatter(x_message, self.target_index_i, dim=0, reduce="sum")
-
-        return x_message
-
+        return scatter(x_message, self.target_index_i, dim=0, reduce="sum")
 
 class MLP(nn.Sequential):
     """MLP Module.


### PR DESCRIPTION
Hello,
@levtelyatnikov and I made some changes to allset_transformer_layer. 
We noticed that the old implementation required a lot of memory when calculating the attention scores when dealing with large graphs. Now the layer achieves the same results with less memory requirements.
We also introduced a LeakyReLU activation when calculating the attention as per the [official code implementation](https://github.com/jianhao2016/AllSet/blob/main/src/layers.py) (lines 168-177). 
Thank you very much.