### PR TITLE
Update torch dependency in tests

### DIFF
--- a/.github/workflows/test_codebase.yml
+++ b/.github/workflows/test_codebase.yml
@@ -27,9 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        torch-version: [2.0.1]
-        include:
-          - torch-version: 2.0.1
+        torch-version: ["2.3.0"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -30,9 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        torch-version: [2.0.1]
-        include:
-          - torch-version: 2.0.1
+        torch-version: ["2.3.0"]
         test-group: [1, 2, 3, 4]
 
     steps:
@@ -64,9 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        torch-version: [2.0.1]
-        include:
-          - torch-version: 2.0.1
+        torch-version: ["2.3.0"]
         test-group: [1, 2, 3]
 
     steps:
@@ -98,9 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        torch-version: [2.0.1]
-        include:
-          - torch-version: 2.0.1
+        torch-version: ["2.3.0"]
 
     steps:
       - uses: actions/checkout@v4
@@ -131,9 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        torch-version: [2.0.1]
-        include:
-          - torch-version: 2.0.1
+        torch-version: ["2.3.0"]
 
     steps:
       - uses: actions/checkout@v4

--- a/tutorials/combinatorial/hmc_train.ipynb
+++ b/tutorials/combinatorial/hmc_train.ipynb
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:49:28.758850145Z",
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:49:28.810114967Z",
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:49:29.818662234Z",
@@ -349,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:50:47.902394227Z",
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:55:26.795250682Z",
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:55:26.814069014Z",
@@ -612,7 +612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T06:55:28.220563261Z",
@@ -713,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -771,7 +771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T07:01:54.496249166Z",
@@ -821,7 +821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-08-24T07:13:58.198454432Z",


### PR DESCRIPTION
Support for NumPy 2.0 was added in PyTorch 2.2 and above.