### PR TITLE
Test against Python 3.12

### DIFF
--- a/.github/workflows/test_codebase.yml
+++ b/.github/workflows/test_codebase.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1
@@ -103,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         torch-version: [2.0.1]
         include:
           - torch-version: 2.0.1


### PR DESCRIPTION
We need to update to PyTorch 2.2 for Python 3.12 support. Waiting on #281 to be merged.

See #293.