### PR TITLE
HyperGat layer attention fix

### DIFF
--- a/topomodelx/nn/hypergraph/hypergat_layer.py
+++ b/topomodelx/nn/hypergraph/hypergat_layer.py
@@ -200,7 +200,7 @@ class HyperGATLayer(MessagePassing):
         inter_aggregation = incidence_1 @ (messages_on_edges @ self.weight2)
 
         attention_values = self.attention(
-            inter_aggregation, intra_aggregation
+            inter_aggregation, intra_aggregation, "edge-level"
         ).squeeze()
         incidence_with_attention = torch.sparse_coo_tensor(
             indices=incidence_1.indices(),


### PR DESCRIPTION
In the HyperGat [paper](https://aclanthology.org/2020.emnlp-main.399.pdf), the second attention calculation should compute the edge-level attention. The `attention` function in `hypergat_layer.py` computes a node-level attention by default, so here the mechanism `"edge_level"` should be explicitly specified. 