### PR TITLE
Modernize codebase

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11.3]
-        torch-version: [2.0.1]
-        include:
-          - torch-version: 2.0.1
+        python-version: [3.13]
+        torch-version: [2.8.0]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_codebase.yml
+++ b/.github/workflows/test_codebase.yml
@@ -26,22 +26,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12", "3.14"]
         torch-version: ["2.8.0", "2.12.0"]
+        exclude:
+          # torch 2.8 has no cp314 wheels
+          - python-version: "3.14"
+            torch-version: "2.8.0"
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Install PyTorch ${{ matrix.torch-version }}+cpu
         run: |
+          uv venv
           uv pip install torch==${{ matrix.torch-version}} --extra-index-url https://download.pytorch.org/whl/cpu
-          uv pip install pyg_lib torch_scatter torch_sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
+          uv pip install pyg_lib -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: uv pip install -e .[all]

--- a/.github/workflows/test_tutorials.yml
+++ b/.github/workflows/test_tutorials.yml
@@ -29,23 +29,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12", "3.14"]
         torch-version: ["2.8.0", "2.12.0"]
+        exclude:
+          # torch 2.8 has no cp314 wheels
+          - python-version: "3.14"
+            torch-version: "2.8.0"
         test-group: [1, 2, 3, 4]
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Install PyTorch ${{ matrix.torch-version }}+cpu
         run: |
+          uv venv
           uv pip install torch==${{ matrix.torch-version}} --extra-index-url https://download.pytorch.org/whl/cpu
-          uv pip install pyg_lib torch_scatter torch_sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
+          uv pip install pyg_lib -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: uv pip install -e .[all]
@@ -59,23 +64,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12", "3.14"]
         torch-version: ["2.8.0", "2.12.0"]
+        exclude:
+          # torch 2.8 has no cp314 wheels
+          - python-version: "3.14"
+            torch-version: "2.8.0"
         test-group: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Install PyTorch ${{ matrix.torch-version }}+cpu
         run: |
+          uv venv
           uv pip install torch==${{ matrix.torch-version}} --extra-index-url https://download.pytorch.org/whl/cpu
-          uv pip install pyg_lib torch_scatter torch_sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
+          uv pip install pyg_lib -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: uv pip install -e .[all]
@@ -89,22 +99,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12", "3.14"]
         torch-version: ["2.8.0", "2.12.0"]
+        exclude:
+          # torch 2.8 has no cp314 wheels
+          - python-version: "3.14"
+            torch-version: "2.8.0"
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Install PyTorch ${{ matrix.torch-version }}+cpu
         run: |
+          uv venv
           uv pip install torch==${{ matrix.torch-version}} --extra-index-url https://download.pytorch.org/whl/cpu
-          uv pip install pyg_lib torch_scatter torch_sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
+          uv pip install pyg_lib -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: uv pip install -e .[all]
@@ -118,22 +133,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12", "3.14"]
         torch-version: ["2.8.0", "2.12.0"]
+        exclude:
+          # torch 2.8 has no cp314 wheels
+          - python-version: "3.14"
+            torch-version: "2.8.0"
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
       - name: Install PyTorch ${{ matrix.torch-version }}+cpu
         run: |
+          uv venv
           uv pip install torch==${{ matrix.torch-version}} --extra-index-url https://download.pytorch.org/whl/cpu
-          uv pip install pyg_lib torch_scatter torch_sparse -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
+          uv pip install pyg_lib -f https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html
 
       - name: Install main package
         run: uv pip install -e .[all]

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ where `${CUDA}` should be replaced by either `cpu`, `cu102`, `cu113`, or `cu115`
 
 To develop tmx on your machine, here are some tips.
 
-First, we recommend using Python 3.11.3, which is the python version used to run the unit-tests.
+First, we recommend using Python 3.12 or later, matching the [SPEC 0](https://scientific-python.org/specs/spec-0000/) recommendation.
 
 For example, create a conda environment:
    ```bash
-   conda create -n tmx python=3.11.3
+   conda create -n tmx python=3.12
    conda activate tmx
    ```
 
@@ -140,8 +140,6 @@ Then:
    ```bash
    pytest
    ```
-
-   In case an error occurs, please first check if all sub-packages ([`torch-scatter`](https://github.com/rusty1s/pytorch_scatter), [`torch-sparse`](https://github.com/rusty1s/pytorch_sparse), [`torch-cluster`](https://github.com/rusty1s/pytorch_cluster) and [`torch-spline-conv`](https://github.com/rusty1s/pytorch_spline_conv)) are on its latest reported version.
 
 6. Install pre-commit hooks:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,19 +23,18 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
-requires-python = ">= 3.11"
+requires-python = ">= 3.12"
 dependencies=[
     "tqdm",
-    "numpy<2",
-    "scipy",
+    "numpy>=2.2",
+    "scipy>=1.15",
     "requests",
-    "scikit-learn",
-    "matplotlib",
-    "networkx",
+    "networkx>=3.4",
     "gudhi",
-    "pandas",
     "torch_geometric",
     "torch>=2.8.0",
     "toponetx",
@@ -45,9 +44,11 @@ dependencies=[
 doc = [
     "hypernetx",
     "jupyter",
+    "matplotlib>=3.10",
     "nbsphinx",
     "nbsphinx_link",
     "numpydoc",
+    "scikit-learn>=1.6",
     "sphinx",
     "sphinx-copybutton",
     "sphinx_gallery",
@@ -145,7 +146,6 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 show_error_codes = true
 disable_error_code = ["import-untyped"]
-plugins = "numpy.typing.mypy_plugin"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
@@ -156,6 +156,7 @@ filterwarnings = [
     "ignore::scipy.sparse._base.SparseEfficiencyWarning",
     "ignore:Sparse CSR tensor support is in beta state:UserWarning",
     "ignore:`torch.jit.script` is deprecated",
+    "ignore:`torch.jit.script` is not supported in Python 3.14",
 ]
 log_cli_level = "info"
 testpaths = ["test"]

--- a/test/utils/test_sparse.py
+++ b/test/utils/test_sparse.py
@@ -10,7 +10,7 @@ from topomodelx.utils.sparse import from_sparse
 def test_from_sparse():
     """Tests from_sparse matches sparse -> dense -> sparse."""
     # test values matche
-    test_matrix = sparse._csc.csc_matrix(np.random.default_rng().random((100, 100)))
+    test_matrix = sparse.csc_matrix(np.random.default_rng().random((100, 100)))
     a = torch.from_numpy(test_matrix.todense()).to_sparse()
     b = from_sparse(test_matrix)
 

--- a/topomodelx/nn/hypergraph/allset_transformer_layer.py
+++ b/topomodelx/nn/hypergraph/allset_transformer_layer.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from torch_geometric.utils import softmax
-from torch_scatter import scatter
 
 from topomodelx.base.message_passing import MessagePassing
 
@@ -408,7 +407,12 @@ class MultiHeadAttention(MessagePassing):
         x_message = x_message.permute(1, 0, 2)[
             self.source_index_j
         ] * attention_values.unsqueeze(-1)
-        return scatter(x_message, self.target_index_i, dim=0, reduce="sum")
+        index = self.target_index_i
+        dim_size = int(index.max()) + 1 if index.numel() else 0
+        index = index.view(-1, *([1] * (x_message.dim() - 1))).expand_as(x_message)
+        return x_message.new_zeros((dim_size, *x_message.shape[1:])).scatter_reduce_(
+            0, index, x_message, reduce="sum"
+        )
 
 
 class MLP(nn.Sequential):

--- a/topomodelx/utils/sparse.py
+++ b/topomodelx/utils/sparse.py
@@ -2,15 +2,15 @@
 
 import numpy as np
 import torch
-from scipy.sparse import _csc
+from scipy import sparse
 
 
-def from_sparse(data: _csc.csc_matrix) -> torch.Tensor:
+def from_sparse(data: sparse.spmatrix | sparse.sparray) -> torch.Tensor:
     """Convert sparse input data directly to torch sparse coo format.
 
     Parameters
     ----------
-    data : scipy.sparse._csc.csc_matrix
+    data : scipy.sparse.spmatrix or scipy.sparse.sparray
         Input n_dimensional data.
 
     Returns


### PR DESCRIPTION
- Set dependency constraints as per Scientific Python's SPEC 0 recommendation
- Drop `torch_scatter` dependency (native PyTorch functions are good enough for us)