### PR TITLE
Fix MessagePassing output shape for isolated target cells

### DIFF
--- a/test/base/test_message_passing.py
+++ b/test/base/test_message_passing.py
@@ -116,3 +116,11 @@ class TestMessagePassing:
             self.x_source, self.neighborhood_r_to_s, self.x_target
         )
         assert result.shape == (2, 2)
+
+    def test_forward_isolated_target(self):
+        """Test forward with target cells that have no incoming messages."""
+        x_source = torch.rand((3, 10))
+        neighborhood = torch.tensor([[1, 0, 1], [0, 0, 0]]).to_sparse_coo().float()
+
+        result = self.mp.forward(x_source, neighborhood)
+        assert result.shape == (2, 10)

--- a/topomodelx/base/message_passing.py
+++ b/topomodelx/base/message_passing.py
@@ -185,10 +185,16 @@ class MessagePassing(torch.nn.Module):
         Tensor, shape = (...,  n_target_cells, out_channels)
             Output features on target cells.
             Each target cell aggregates messages from several source cells.
+            Target cells with an empty neighborhood receive zero features.
             Assumes that all target cells have the same rank s.
         """
         aggr = scatter(self.aggr_func)
-        return aggr(x_message, self.target_index_i, 0)
+        return aggr(
+            x_message,
+            self.target_index_i,
+            0,
+            dim_size=getattr(self, "n_target_cells", None),
+        )
 
     def forward(self, x_source, neighborhood, x_target=None):
         r"""Forward pass.
@@ -259,6 +265,7 @@ class MessagePassing(torch.nn.Module):
         """
         neighborhood = neighborhood.coalesce()
         self.target_index_i, self.source_index_j = neighborhood.indices()
+        self.n_target_cells = neighborhood.shape[0]
         neighborhood_values = neighborhood.values()
 
         x_message = self.message(x_source=x_source, x_target=x_target)


### PR DESCRIPTION
The scatter aggregation inferred the output size from the largest message index, silently dropping target cells without incoming messages and contradicting the documented output shape.

Pass the number of target cells from the neighborhood matrix as dim_size so that every target cell receives an output row, zero-filled when its neighborhood is empty.

Fixes #136

Also resolves the reported Conv scenario of #228, where an isolated last cell previously led to a wrong output shape.