### PR TITLE
Fix vacuous reset_parameters tests

### DIFF
--- a/test/nn/simplicial/test_hsn_layer.py
+++ b/test/nn/simplicial/test_hsn_layer.py
@@ -28,13 +28,13 @@ class TestHSNLayer:
         channels = 5
 
         hsn = HSNLayer(channels)
+
+        with torch.no_grad():
+            for param in hsn.parameters():
+                param.fill_(1234.0)
+
         hsn.reset_parameters()
 
-        for module in hsn.modules():
-            if isinstance(module, torch.nn.Conv2d):
-                torch.testing.assert_allclose(
-                    module.weight, torch.zeros_like(module.weight)
-                )
-                torch.testing.assert_allclose(
-                    module.bias, torch.zeros_like(module.bias)
-                )
+        for name, param in hsn.named_parameters():
+            assert torch.isfinite(param).all(), name
+            assert not torch.all(param == 1234.0), name

--- a/test/nn/simplicial/test_scconv_layer.py
+++ b/test/nn/simplicial/test_scconv_layer.py
@@ -61,13 +61,13 @@ class TestSCConvLayer:
         face_channels = 7
 
         scconv = SCConvLayer(node_channels, edge_channels, face_channels)
+
+        with torch.no_grad():
+            for param in scconv.parameters():
+                param.fill_(1234.0)
+
         scconv.reset_parameters()
 
-        for module in scconv.modules():
-            if isinstance(module, torch.nn.Conv2d):
-                torch.testing.assert_allclose(
-                    module.weight, torch.zeros_like(module.weight)
-                )
-                torch.testing.assert_allclose(
-                    module.bias, torch.zeros_like(module.bias)
-                )
+        for name, param in scconv.named_parameters():
+            assert torch.isfinite(param).all(), name
+            assert not torch.all(param == 1234.0), name

--- a/test/nn/simplicial/test_scn2_layer.py
+++ b/test/nn/simplicial/test_scn2_layer.py
@@ -44,13 +44,13 @@ class TestSCN2Layer:
         channels_2 = 30
 
         scn = SCN2Layer(channels_0, channels_1, channels_2)
+
+        with torch.no_grad():
+            for param in scn.parameters():
+                param.fill_(1234.0)
+
         scn.reset_parameters()
 
-        for module in scn.modules():
-            if isinstance(module, torch.nn.Conv2d):
-                torch.testing.assert_allclose(
-                    module.weight, torch.zeros_like(module.weight)
-                )
-                torch.testing.assert_allclose(
-                    module.bias, torch.zeros_like(module.bias)
-                )
+        for name, param in scn.named_parameters():
+            assert torch.isfinite(param).all(), name
+            assert not torch.all(param == 1234.0), name


### PR DESCRIPTION
The reset_parameters tests of HSNLayer, SCConvLayer and SCN2Layer only asserted on torch.nn.Conv2d modules, which these layers do not contain, so the loop body never executed and the tests passed without checking anything. The zeros comparison would have been wrong regardless, since the layers initialize with Xavier schemes.

Fill all parameters with a sentinel value, reset, and assert that every parameter changed and remains finite.

Fixes #140