### PR TITLE
Fix AllSet instantiation with default activation

### DIFF
--- a/topomodelx/nn/hypergraph/allset.py
+++ b/topomodelx/nn/hypergraph/allset.py
@@ -22,7 +22,7 @@ class AllSet(torch.nn.Module):
         Dropout probability for the AllSet layer.
     mlp_num_layers : int, default = 2
         Number of layers in the MLP.
-    mlp_activation : torch.nn.Module, default = None
+    mlp_activation : callable | None, default = torch.nn.ReLU
         Activation function in the MLP.
     mlp_dropout : float, default = 0.0
         Dropout probability for the MLP.

--- a/topomodelx/nn/hypergraph/allset.py
+++ b/topomodelx/nn/hypergraph/allset.py
@@ -46,7 +46,7 @@ class AllSet(torch.nn.Module):
         n_layers=2,
         layer_dropout=0.2,
         mlp_num_layers=2,
-        mlp_activation=None,
+        mlp_activation=torch.nn.ReLU,
         mlp_dropout=0.0,
         mlp_norm=None,
         **kwargs,

--- a/topomodelx/nn/hypergraph/allset_layer.py
+++ b/topomodelx/nn/hypergraph/allset_layer.py
@@ -175,7 +175,8 @@ class MLP(nn.Sequential):
             layers.append(nn.Linear(in_dim, hidden_dim, bias=bias))
             if norm_layer is not None:
                 layers.append(norm_layer(hidden_dim))
-            layers.append(activation_layer(**params))
+            if activation_layer is not None:
+                layers.append(activation_layer(**params))
             layers.append(nn.Dropout(dropout, **params))
             in_dim = hidden_dim
 

--- a/topomodelx/nn/hypergraph/allset_transformer_layer.py
+++ b/topomodelx/nn/hypergraph/allset_transformer_layer.py
@@ -191,7 +191,7 @@ class AllSetTransformerBlock(nn.Module):
         number_queries: int = 1,
         dropout: float = 0.0,
         mlp_num_layers: int = 1,
-        mlp_activation=None,
+        mlp_activation=nn.ReLU,
         mlp_dropout: float = 0.0,
         mlp_norm=None,
         initialization: Literal["xavier_uniform", "xavier_normal"] = "xavier_uniform",
@@ -455,7 +455,8 @@ class MLP(nn.Sequential):
             layers.append(nn.Linear(in_dim, hidden_dim, bias=bias))
             if norm_layer is not None:
                 layers.append(norm_layer(hidden_dim))
-            layers.append(activation_layer(**params))
+            if activation_layer is not None:
+                layers.append(activation_layer(**params))
             layers.append(nn.Dropout(dropout, **params))
             in_dim = hidden_dim
 


### PR DESCRIPTION
AllSet defaulted mlp_activation to None, which overrode the nn.ReLU default of AllSetLayer and reached the MLP helper, where the activation class was called unconditionally, raising TypeError: 'NoneType' object is not callable on construction.

- Default mlp_activation to torch.nn.ReLU in AllSet
- Skip None activations in both copy-pasted MLP helpers, mirroring the existing norm_layer guard
- Apply the same fixes to AllSetTransformerBlock and its MLP helper, which shared the latent bug

Fixes #307